### PR TITLE
Add table collision detection with buffer time support

### DIFF
--- a/backend/app/api/v1/endpoint/game_session.py
+++ b/backend/app/api/v1/endpoint/game_session.py
@@ -123,6 +123,30 @@ async def delete_session(
 
 
 # =============================================================================
+# Table Assignment
+# =============================================================================
+
+@router.post("/{session_id}/assign-table", response_model=GameSessionRead)
+async def assign_table(
+    session_id: UUID,
+    table_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Assign a physical table to a session.
+
+    Validates:
+    - No collision with other sessions on the same table
+    - Respects buffer time between sessions
+
+    Requires: Organizer or SUPER_ADMIN.
+    """
+    service = GameSessionService(db)
+    return await service.assign_table(session_id, table_id, current_user)
+
+
+# =============================================================================
 # Workflow Endpoints
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- Implements Issue #1 - Temporal Engine collision check for table assignments
- Adds `_check_table_collision()` method to detect overlapping sessions on same physical table
- Adds `assign_table()` service method with proper validation and permission checks
- Adds `POST /sessions/{id}/assign-table` endpoint
- Respects exhibition `buffer_time` setting between sessions

## Test plan

- [x] `test_assign_table_success` - Basic table assignment works
- [x] `test_assign_table_collision` - Detects overlapping sessions on same table
- [x] `test_assign_table_with_buffer` - Sessions just outside buffer window can share table
- [x] `test_assign_table_respects_buffer` - Sessions within buffer window are rejected
- [x] `test_assign_different_tables_no_collision` - Different tables don't conflict

All 93 tests passing.

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)