### PR TITLE
Add double-booking prevention and no-show functionality

### DIFF
--- a/backend/app/api/v1/endpoint/game_session.py
+++ b/backend/app/api/v1/endpoint/game_session.py
@@ -260,3 +260,20 @@ async def check_in_booking(
     """
     service = GameSessionService(db)
     return await service.check_in_booking(booking_id, current_user)
+
+
+@router.post("/bookings/{booking_id}/no-show", response_model=BookingRead)
+async def mark_no_show(
+    booking_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Mark a booking as no-show.
+
+    Frees up a spot and may promote someone from waitlist.
+
+    Can be done by: session creator (GM) or organizer.
+    """
+    service = GameSessionService(db)
+    return await service.mark_no_show(booking_id, current_user)


### PR DESCRIPTION
Implements Issue #5 - Booking registration & check-in logic:
- Add _check_booking_overlap() to prevent users booking overlapping sessions
- Add mark_no_show() service method for GMs/organizers
- Add POST /bookings/{id}/no-show endpoint
- No-show frees up a spot and promotes from waitlist
- Fix enum.value AttributeError on booking status
- 7 new tests covering overlap and no-show scenarios

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
