### PR TITLE
Add partner permissions for zone management

### DIFF
--- a/backend/app/domain/exhibition/schemas.py
+++ b/backend/app/domain/exhibition/schemas.py
@@ -132,6 +132,21 @@ class ZoneCreate(ZoneBase):
     delegated_to_group_id: Optional[UUID] = None
 
 
+class ZoneUpdate(BaseModel):
+    """Schema for updating a zone."""
+    name: Optional[str] = Field(None, min_length=1, max_length=100)
+    description: Optional[str] = None
+    type: Optional[ZoneType] = None
+
+
+class ZoneDelegate(BaseModel):
+    """Schema for delegating a zone to a partner group."""
+    delegated_to_group_id: Optional[UUID] = Field(
+        None,
+        description="UserGroup ID to delegate zone to. Set to null to remove delegation."
+    )
+
+
 class ZoneRead(ZoneBase):
     """Schema for reading a zone."""
     id: UUID


### PR DESCRIPTION
Implements Issue #3 - Multi-Tenant & Partner Permissions:
- Add ZoneUpdate and ZoneDelegate schemas
- Add PUT /zones/{id} endpoint for zone updates
- Add POST /zones/{id}/delegate endpoint for zone delegation
- Use require_zone_manager dependency for proper permission checks
- Partners can only manage zones delegated to their group
- Organizers can delegate/remove zone delegation
- 7 new tests for delegation and partner permissions

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
