### PR TITLE
Add operations API for auto-cancellation and pop-up games

### DIFF
--- a/backend/app/api/v1/endpoint/operations.py
+++ b/backend/app/api/v1/endpoint/operations.py
@@ -1,0 +1,107 @@
+"""
+Operations API endpoints.
+
+Real-time operations: available tables, auto-cancellation, GM check-in.
+"""
+from datetime import datetime
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.domain.exhibition.schemas import PhysicalTableRead
+from app.domain.game.schemas import GameSessionRead
+from app.domain.user.entity import User
+from app.domain.shared.entity import GlobalRole
+from app.api.deps import get_current_active_user
+from app.services.operations import OperationsService
+
+router = APIRouter()
+
+
+@router.get("/exhibitions/{exhibition_id}/available-tables", response_model=List[PhysicalTableRead])
+async def get_available_tables(
+    exhibition_id: UUID,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Get tables available for immediate use (pop-up games).
+
+    Returns tables that are not currently occupied by any session.
+    Useful for spontaneous games when someone wants to run a game right now.
+    """
+    service = OperationsService(db)
+    return await service.get_available_tables(exhibition_id)
+
+
+@router.post("/exhibitions/{exhibition_id}/auto-cancel", response_model=List[GameSessionRead])
+async def auto_cancel_sessions(
+    exhibition_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Auto-cancel sessions where GM hasn't checked in after grace period.
+
+    This endpoint can be called manually by organizers or triggered by a background job.
+
+    Requires: Organizer or SUPER_ADMIN.
+    """
+    if current_user.global_role not in [GlobalRole.SUPER_ADMIN, GlobalRole.ORGANIZER]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only organizers can trigger auto-cancellation",
+        )
+
+    service = OperationsService(db)
+    cancelled = await service.auto_cancel_sessions(exhibition_id)
+
+    return cancelled
+
+
+@router.post("/sessions/{session_id}/gm-check-in", response_model=GameSessionRead)
+async def gm_check_in(
+    session_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Check in the GM for a session.
+
+    Marks the session as IN_PROGRESS and records the check-in time.
+    This prevents the session from being auto-cancelled.
+
+    Can be done by: session creator (GM) or organizer.
+    """
+    from sqlalchemy import select
+    from app.domain.game.entity import GameSession
+
+    # Get session to check permissions
+    result = await db.execute(
+        select(GameSession).where(GameSession.id == session_id)
+    )
+    session = result.scalar_one_or_none()
+
+    if not session:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Game session not found",
+        )
+
+    # Check permission - GM or organizer
+    can_check_in = (
+        session.created_by_user_id == current_user.id
+        or current_user.global_role in [GlobalRole.SUPER_ADMIN, GlobalRole.ORGANIZER]
+    )
+    if not can_check_in:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only the GM or organizers can check in for a session",
+        )
+
+    service = OperationsService(db)
+    updated_session = await service.gm_check_in(session_id)
+
+    return updated_session

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@ FastAPI application entry point.
 """
 from fastapi import FastAPI
 
-from app.api.v1.endpoint import admin, exhibition, organization, zone, game_session
+from app.api.v1.endpoint import admin, exhibition, organization, zone, game_session, operations
 
 app = FastAPI(
     title="Structura Ludis API",
@@ -36,6 +36,11 @@ app.include_router(
     admin.router,
     prefix="/api/v1/admin",
     tags=["Admin"],
+)
+app.include_router(
+    operations.router,
+    prefix="/api/v1/ops",
+    tags=["Operations"],
 )
 
 

--- a/backend/app/services/operations.py
+++ b/backend/app/services/operations.py
@@ -1,0 +1,166 @@
+"""
+Operations service layer.
+
+Contains business logic for real-time operations: available tables, auto-cancellation.
+"""
+from datetime import datetime, timedelta, timezone
+from typing import List
+from uuid import UUID
+
+from sqlalchemy import select, and_, or_, not_
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.exhibition.entity import Exhibition, PhysicalTable, Zone
+from app.domain.game.entity import GameSession
+from app.domain.shared.entity import SessionStatus, PhysicalTableStatus
+
+
+class OperationsService:
+    """Service for real-time operations during an exhibition."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_available_tables(
+        self,
+        exhibition_id: UUID,
+        at_time: datetime = None,
+    ) -> List[PhysicalTable]:
+        """
+        Get tables available for immediate use (pop-up games).
+
+        A table is available if:
+        - It belongs to the exhibition
+        - Its status is AVAILABLE
+        - No validated/in-progress session is using it at the given time
+        """
+        if at_time is None:
+            at_time = datetime.now(timezone.utc)
+
+        # Get all tables in the exhibition's zones
+        tables_query = (
+            select(PhysicalTable)
+            .join(Zone, PhysicalTable.zone_id == Zone.id)
+            .where(
+                Zone.exhibition_id == exhibition_id,
+                PhysicalTable.status == PhysicalTableStatus.AVAILABLE,
+            )
+        )
+        tables_result = await self.db.execute(tables_query)
+        all_tables = tables_result.scalars().all()
+
+        # Get tables currently occupied by sessions
+        occupied_query = (
+            select(GameSession.physical_table_id)
+            .where(
+                GameSession.exhibition_id == exhibition_id,
+                GameSession.physical_table_id.isnot(None),
+                GameSession.status.in_([
+                    SessionStatus.VALIDATED,
+                    SessionStatus.IN_PROGRESS,
+                ]),
+                GameSession.scheduled_start <= at_time,
+                GameSession.scheduled_end > at_time,
+            )
+        )
+        occupied_result = await self.db.execute(occupied_query)
+        occupied_table_ids = {row[0] for row in occupied_result.fetchall()}
+
+        # Filter out occupied tables
+        available_tables = [
+            table for table in all_tables
+            if table.id not in occupied_table_ids
+        ]
+
+        return available_tables
+
+    async def get_sessions_to_cancel(
+        self,
+        exhibition_id: UUID,
+        current_time: datetime = None,
+    ) -> List[GameSession]:
+        """
+        Get sessions that should be auto-cancelled due to GM no-show.
+
+        A session should be cancelled if:
+        - Status is VALIDATED (not started yet)
+        - scheduled_start + grace_period has passed
+        - GM has not checked in (gm_checked_in_at is null)
+        """
+        if current_time is None:
+            current_time = datetime.now(timezone.utc)
+
+        # Get exhibition's grace period
+        exhibition_result = await self.db.execute(
+            select(Exhibition).where(Exhibition.id == exhibition_id)
+        )
+        exhibition = exhibition_result.scalar_one_or_none()
+
+        if not exhibition:
+            return []
+
+        grace_period = timedelta(minutes=exhibition.grace_period_minutes)
+        cutoff_time = current_time - grace_period
+
+        # Find sessions past grace period without GM check-in
+        query = select(GameSession).where(
+            GameSession.exhibition_id == exhibition_id,
+            GameSession.status == SessionStatus.VALIDATED,
+            GameSession.scheduled_start <= cutoff_time,
+            GameSession.gm_checked_in_at.is_(None),
+        )
+
+        result = await self.db.execute(query)
+        return result.scalars().all()
+
+    async def auto_cancel_sessions(
+        self,
+        exhibition_id: UUID,
+        current_time: datetime = None,
+    ) -> List[GameSession]:
+        """
+        Auto-cancel sessions where GM hasn't checked in after grace period.
+
+        Returns list of cancelled sessions.
+        """
+        sessions = await self.get_sessions_to_cancel(exhibition_id, current_time)
+
+        for session in sessions:
+            session.status = SessionStatus.CANCELLED
+
+        if sessions:
+            await self.db.flush()
+            for session in sessions:
+                await self.db.refresh(session)
+
+        return sessions
+
+    async def gm_check_in(
+        self,
+        session_id: UUID,
+        current_time: datetime = None,
+    ) -> GameSession:
+        """
+        Check in the GM for a session.
+
+        Transitions session to IN_PROGRESS status.
+        """
+        if current_time is None:
+            current_time = datetime.now(timezone.utc)
+
+        result = await self.db.execute(
+            select(GameSession).where(GameSession.id == session_id)
+        )
+        session = result.scalar_one_or_none()
+
+        if not session:
+            return None
+
+        session.gm_checked_in_at = current_time
+        session.status = SessionStatus.IN_PROGRESS
+        session.actual_start = current_time
+
+        await self.db.flush()
+        await self.db.refresh(session)
+
+        return session

--- a/backend/tests/api/v1/test_operations.py
+++ b/backend/tests/api/v1/test_operations.py
@@ -1,0 +1,370 @@
+"""
+Tests for Operations API endpoints.
+"""
+import pytest
+from datetime import datetime, timedelta
+from uuid import uuid4
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.game.entity import GameCategory, Game, GameSession
+from app.domain.shared.entity import GameComplexity, SessionStatus
+
+
+@pytest.fixture
+async def test_game_category(db_session: AsyncSession) -> dict:
+    """Create a test game category."""
+    category = GameCategory(
+        id=uuid4(),
+        name="Role-Playing Games",
+        slug="rpg-ops",
+    )
+    db_session.add(category)
+    await db_session.commit()
+    await db_session.refresh(category)
+
+    return {
+        "id": str(category.id),
+        "name": category.name,
+        "slug": category.slug,
+    }
+
+
+@pytest.fixture
+async def test_game(db_session: AsyncSession, test_game_category: dict) -> dict:
+    """Create a test game."""
+    game = Game(
+        id=uuid4(),
+        category_id=test_game_category["id"],
+        title="Test RPG",
+        publisher="Test Publisher",
+        complexity=GameComplexity.INTERMEDIATE,
+        min_players=3,
+        max_players=6,
+    )
+    db_session.add(game)
+    await db_session.commit()
+    await db_session.refresh(game)
+
+    return {
+        "id": str(game.id),
+        "title": game.title,
+        "category_id": test_game_category["id"],
+    }
+
+
+@pytest.fixture
+async def ops_exhibition_setup(auth_client: AsyncClient, test_organizer: dict) -> dict:
+    """Create an exhibition with zones, tables, and time slots for operations tests."""
+    from datetime import timezone
+    # Use current time for the exhibition to allow testing with "now" times
+    now = datetime.now(timezone.utc)
+    start_date = (now - timedelta(hours=2)).isoformat()
+    end_date = (now + timedelta(days=2)).isoformat()
+    slot_start = (now - timedelta(hours=1)).isoformat()
+    slot_end = (now + timedelta(hours=5)).isoformat()
+
+    # Create exhibition with 15 min grace period
+    exhibition_payload = {
+        "title": "Ops Test Convention",
+        "slug": "ops-test-convention-" + str(uuid4())[:8],
+        "start_date": start_date,
+        "end_date": end_date,
+        "organization_id": test_organizer["organization_id"],
+        "grace_period_minutes": 15,
+    }
+    exhibition_resp = await auth_client.post("/api/v1/exhibitions/", json=exhibition_payload)
+    exhibition_id = exhibition_resp.json()["id"]
+
+    # Create time slot spanning current time
+    slot_payload = {
+        "name": "Current Slot",
+        "start_time": slot_start,
+        "end_time": slot_end,
+        "max_duration_minutes": 360,
+        "buffer_time_minutes": 15,
+    }
+    slot_resp = await auth_client.post(
+        f"/api/v1/exhibitions/{exhibition_id}/slots", json=slot_payload
+    )
+    time_slot_id = slot_resp.json()["id"]
+
+    # Create zone with tables
+    zone_payload = {"name": "Main Hall", "exhibition_id": exhibition_id}
+    zone_resp = await auth_client.post("/api/v1/zones/", json=zone_payload)
+    zone_id = zone_resp.json()["id"]
+
+    tables_resp = await auth_client.post(
+        f"/api/v1/zones/{zone_id}/batch-tables",
+        json={"prefix": "T", "count": 5},
+    )
+    tables = tables_resp.json()["tables"]
+
+    return {
+        "exhibition_id": exhibition_id,
+        "time_slot_id": time_slot_id,
+        "zone_id": zone_id,
+        "tables": tables,
+        "slot_start": slot_start,
+        "slot_end": slot_end,
+    }
+
+
+class TestAvailableTables:
+    """Tests for GET /api/v1/ops/exhibitions/{id}/available-tables"""
+
+    async def test_all_tables_available_when_no_sessions(
+        self,
+        auth_client: AsyncClient,
+        ops_exhibition_setup: dict,
+    ):
+        """All tables available when no sessions are running."""
+        response = await auth_client.get(
+            f"/api/v1/ops/exhibitions/{ops_exhibition_setup['exhibition_id']}/available-tables"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 5  # All 5 tables
+
+    async def test_table_unavailable_during_session(
+        self,
+        auth_client: AsyncClient,
+        ops_exhibition_setup: dict,
+        test_game: dict,
+    ):
+        """Table is not available when session is running on it."""
+        from datetime import timezone
+        # Create and validate a session
+        now = datetime.now(timezone.utc)
+        session_payload = {
+            "title": "Occupied Table Test",
+            "exhibition_id": ops_exhibition_setup["exhibition_id"],
+            "time_slot_id": ops_exhibition_setup["time_slot_id"],
+            "game_id": test_game["id"],
+            "max_players_count": 4,
+            "scheduled_start": (now - timedelta(minutes=30)).isoformat(),
+            "scheduled_end": (now + timedelta(hours=1)).isoformat(),
+        }
+        create_resp = await auth_client.post("/api/v1/sessions/", json=session_payload)
+        session_id = create_resp.json()["id"]
+
+        # Submit and approve
+        await auth_client.post(f"/api/v1/sessions/{session_id}/submit")
+        await auth_client.post(
+            f"/api/v1/sessions/{session_id}/moderate",
+            json={"action": "approve"},
+        )
+
+        # Assign table
+        table_id = ops_exhibition_setup["tables"][0]["id"]
+        await auth_client.post(
+            f"/api/v1/sessions/{session_id}/assign-table",
+            params={"table_id": table_id},
+        )
+
+        # Check available tables - should be 4 now
+        response = await auth_client.get(
+            f"/api/v1/ops/exhibitions/{ops_exhibition_setup['exhibition_id']}/available-tables"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 4
+        # The occupied table should not be in the list
+        table_ids = [t["id"] for t in data]
+        assert table_id not in table_ids
+
+
+class TestAutoCancel:
+    """Tests for POST /api/v1/ops/exhibitions/{id}/auto-cancel"""
+
+    async def test_auto_cancel_no_show_session(
+        self,
+        auth_client: AsyncClient,
+        db_session: AsyncSession,
+        ops_exhibition_setup: dict,
+        test_game: dict,
+    ):
+        """Session is cancelled when GM doesn't check in after grace period."""
+        from datetime import timezone
+        # Create a session that started 20 minutes ago (grace period is 15)
+        now = datetime.now(timezone.utc)
+        past_start = now - timedelta(minutes=20)
+        session_payload = {
+            "title": "No Show Session",
+            "exhibition_id": ops_exhibition_setup["exhibition_id"],
+            "time_slot_id": ops_exhibition_setup["time_slot_id"],
+            "game_id": test_game["id"],
+            "max_players_count": 4,
+            "scheduled_start": past_start.isoformat(),
+            "scheduled_end": (past_start + timedelta(hours=2)).isoformat(),
+        }
+        create_resp = await auth_client.post("/api/v1/sessions/", json=session_payload)
+        session_id = create_resp.json()["id"]
+
+        # Submit and approve
+        await auth_client.post(f"/api/v1/sessions/{session_id}/submit")
+        await auth_client.post(
+            f"/api/v1/sessions/{session_id}/moderate",
+            json={"action": "approve"},
+        )
+
+        # Trigger auto-cancel
+        response = await auth_client.post(
+            f"/api/v1/ops/exhibitions/{ops_exhibition_setup['exhibition_id']}/auto-cancel"
+        )
+
+        assert response.status_code == 200
+        cancelled = response.json()
+        assert len(cancelled) == 1
+        assert cancelled[0]["id"] == session_id
+        assert cancelled[0]["status"] == "CANCELLED"
+
+    async def test_auto_cancel_does_not_affect_checked_in_sessions(
+        self,
+        auth_client: AsyncClient,
+        ops_exhibition_setup: dict,
+        test_game: dict,
+    ):
+        """Sessions where GM checked in are not cancelled."""
+        from datetime import timezone
+        # Create a session that started 20 minutes ago
+        now = datetime.now(timezone.utc)
+        past_start = now - timedelta(minutes=20)
+        session_payload = {
+            "title": "Checked In Session",
+            "exhibition_id": ops_exhibition_setup["exhibition_id"],
+            "time_slot_id": ops_exhibition_setup["time_slot_id"],
+            "game_id": test_game["id"],
+            "max_players_count": 4,
+            "scheduled_start": past_start.isoformat(),
+            "scheduled_end": (past_start + timedelta(hours=2)).isoformat(),
+        }
+        create_resp = await auth_client.post("/api/v1/sessions/", json=session_payload)
+        session_id = create_resp.json()["id"]
+
+        # Submit and approve
+        await auth_client.post(f"/api/v1/sessions/{session_id}/submit")
+        await auth_client.post(
+            f"/api/v1/sessions/{session_id}/moderate",
+            json={"action": "approve"},
+        )
+
+        # GM checks in
+        await auth_client.post(f"/api/v1/ops/sessions/{session_id}/gm-check-in")
+
+        # Trigger auto-cancel
+        response = await auth_client.post(
+            f"/api/v1/ops/exhibitions/{ops_exhibition_setup['exhibition_id']}/auto-cancel"
+        )
+
+        assert response.status_code == 200
+        cancelled = response.json()
+        assert len(cancelled) == 0  # Nothing cancelled
+
+    async def test_auto_cancel_forbidden_for_user(
+        self,
+        auth_client: AsyncClient,
+        client: AsyncClient,
+        test_user: dict,
+        ops_exhibition_setup: dict,
+    ):
+        """Regular user cannot trigger auto-cancel."""
+        response = await client.post(
+            f"/api/v1/ops/exhibitions/{ops_exhibition_setup['exhibition_id']}/auto-cancel",
+            headers={"X-User-ID": test_user["id"]},
+        )
+
+        assert response.status_code == 403
+
+
+class TestGMCheckIn:
+    """Tests for POST /api/v1/ops/sessions/{id}/gm-check-in"""
+
+    async def test_gm_check_in_success(
+        self,
+        auth_client: AsyncClient,
+        ops_exhibition_setup: dict,
+        test_game: dict,
+    ):
+        """GM can check in to their session."""
+        from datetime import timezone
+        # Create and validate a session
+        now = datetime.now(timezone.utc)
+        session_payload = {
+            "title": "GM Check In Test",
+            "exhibition_id": ops_exhibition_setup["exhibition_id"],
+            "time_slot_id": ops_exhibition_setup["time_slot_id"],
+            "game_id": test_game["id"],
+            "max_players_count": 4,
+            "scheduled_start": now.isoformat(),
+            "scheduled_end": (now + timedelta(hours=2)).isoformat(),
+        }
+        create_resp = await auth_client.post("/api/v1/sessions/", json=session_payload)
+        session_id = create_resp.json()["id"]
+
+        # Submit and approve
+        await auth_client.post(f"/api/v1/sessions/{session_id}/submit")
+        await auth_client.post(
+            f"/api/v1/sessions/{session_id}/moderate",
+            json={"action": "approve"},
+        )
+
+        # GM checks in
+        response = await auth_client.post(f"/api/v1/ops/sessions/{session_id}/gm-check-in")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "IN_PROGRESS"
+        assert data["gm_checked_in_at"] is not None
+
+    async def test_gm_check_in_forbidden_for_other_user(
+        self,
+        auth_client: AsyncClient,
+        client: AsyncClient,
+        test_user: dict,
+        ops_exhibition_setup: dict,
+        test_game: dict,
+    ):
+        """Other user cannot check in for a session they don't own."""
+        from datetime import timezone
+        # Create and validate a session (as organizer)
+        now = datetime.now(timezone.utc)
+        session_payload = {
+            "title": "Forbidden Check In Test",
+            "exhibition_id": ops_exhibition_setup["exhibition_id"],
+            "time_slot_id": ops_exhibition_setup["time_slot_id"],
+            "game_id": test_game["id"],
+            "max_players_count": 4,
+            "scheduled_start": now.isoformat(),
+            "scheduled_end": (now + timedelta(hours=2)).isoformat(),
+        }
+        create_resp = await auth_client.post("/api/v1/sessions/", json=session_payload)
+        session_id = create_resp.json()["id"]
+
+        # Submit and approve
+        await auth_client.post(f"/api/v1/sessions/{session_id}/submit")
+        await auth_client.post(
+            f"/api/v1/sessions/{session_id}/moderate",
+            json={"action": "approve"},
+        )
+
+        # Other user tries to check in
+        response = await client.post(
+            f"/api/v1/ops/sessions/{session_id}/gm-check-in",
+            headers={"X-User-ID": test_user["id"]},
+        )
+
+        assert response.status_code == 403
+
+    async def test_gm_check_in_not_found(
+        self,
+        auth_client: AsyncClient,
+    ):
+        """Check in for non-existent session returns 404."""
+        fake_id = "00000000-0000-0000-0000-000000000000"
+
+        response = await auth_client.post(f"/api/v1/ops/sessions/{fake_id}/gm-check-in")
+
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary

- Adds Operations service for real-time event management
- Pop-up games: endpoint to find available tables for spontaneous games
- Auto-cancellation: cancel sessions where GM doesn't check-in after grace period
- GM check-in: prevents auto-cancellation and marks session as IN_PROGRESS

## Endpoints

- `GET /ops/exhibitions/{id}/available-tables` - Tables not currently occupied
- `POST /ops/exhibitions/{id}/auto-cancel` - Trigger auto-cancellation (organizers only)
- `POST /ops/sessions/{id}/gm-check-in` - GM/organizer check-in

## Test plan

- [x] `test_all_tables_available_when_no_sessions` - All tables returned when no sessions
- [x] `test_table_unavailable_during_session` - Occupied table not in available list
- [x] `test_auto_cancel_no_show_session` - Session cancelled after grace period
- [x] `test_auto_cancel_does_not_affect_checked_in_sessions` - Checked-in sessions safe
- [x] `test_auto_cancel_forbidden_for_user` - Regular user cannot trigger
- [x] `test_gm_check_in_success` - GM can check in
- [x] `test_gm_check_in_forbidden_for_other_user` - Other users blocked
- [x] `test_gm_check_in_not_found` - 404 for invalid session

All 115 tests passing.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)