### PR TITLE
Add user dashboard and agenda management (JS.B6)

### DIFF
--- a/backend/app/api/v1/endpoint/user.py
+++ b/backend/app/api/v1/endpoint/user.py
@@ -1,0 +1,347 @@
+"""
+User API endpoints.
+
+User profile and dashboard (JS.B6).
+"""
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.domain.user.entity import User
+from app.domain.user.schemas import (
+    UserRead,
+    UserProfileUpdate,
+    MySessionSummary,
+    MyBookingSummary,
+    UserAgenda,
+)
+from app.domain.game.entity import GameSession, Booking
+from app.domain.exhibition.entity import Exhibition, Zone, PhysicalTable
+from app.domain.shared.entity import SessionStatus, BookingStatus
+from app.api.deps import get_current_active_user
+
+router = APIRouter()
+
+
+# =============================================================================
+# User Profile
+# =============================================================================
+
+@router.get("/me", response_model=UserRead)
+async def get_current_user_profile(
+    current_user: User = Depends(get_current_active_user),
+):
+    """Get current user's profile."""
+    return current_user
+
+
+@router.put("/me", response_model=UserRead)
+async def update_current_user_profile(
+    profile_in: UserProfileUpdate,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Update current user's profile."""
+    update_data = profile_in.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(current_user, field, value)
+
+    await db.flush()
+    await db.refresh(current_user)
+
+    return current_user
+
+
+# =============================================================================
+# User Dashboard / Agenda (JS.B6)
+# =============================================================================
+
+@router.get("/me/sessions", response_model=List[MySessionSummary])
+async def list_my_sessions(
+    exhibition_id: UUID = None,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    List sessions created by the current user (as GM).
+
+    Optionally filter by exhibition.
+    """
+    query = (
+        select(
+            GameSession,
+            Exhibition.title.label("exhibition_title"),
+            Zone.name.label("zone_name"),
+            PhysicalTable.label.label("table_label"),
+        )
+        .join(Exhibition, GameSession.exhibition_id == Exhibition.id)
+        .outerjoin(PhysicalTable, GameSession.physical_table_id == PhysicalTable.id)
+        .outerjoin(Zone, PhysicalTable.zone_id == Zone.id)
+        .where(GameSession.created_by_user_id == current_user.id)
+        .order_by(GameSession.scheduled_start)
+    )
+
+    if exhibition_id:
+        query = query.where(GameSession.exhibition_id == exhibition_id)
+
+    result = await db.execute(query)
+    rows = result.all()
+
+    sessions = []
+    for row in rows:
+        session = row[0]
+        exhibition_title = row[1]
+        zone_name = row[2]
+        table_label = row[3]
+
+        # Count confirmed and waitlist bookings
+        booking_counts = await db.execute(
+            select(
+                Booking.status,
+                func.count(Booking.id),
+            )
+            .where(Booking.game_session_id == session.id)
+            .group_by(Booking.status)
+        )
+        counts = {row[0]: row[1] for row in booking_counts.fetchall()}
+
+        confirmed = counts.get(BookingStatus.CONFIRMED, 0) + counts.get(BookingStatus.CHECKED_IN, 0)
+        waitlist = counts.get(BookingStatus.WAITING_LIST, 0)
+
+        sessions.append(MySessionSummary(
+            id=session.id,
+            title=session.title,
+            exhibition_id=session.exhibition_id,
+            exhibition_title=exhibition_title,
+            status=session.status,
+            scheduled_start=session.scheduled_start,
+            scheduled_end=session.scheduled_end,
+            zone_name=zone_name,
+            table_label=table_label,
+            max_players_count=session.max_players_count,
+            confirmed_players=confirmed,
+            waitlist_count=waitlist,
+        ))
+
+    return sessions
+
+
+@router.get("/me/bookings", response_model=List[MyBookingSummary])
+async def list_my_bookings(
+    exhibition_id: UUID = None,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    List bookings for the current user (as player).
+
+    Optionally filter by exhibition.
+    """
+    query = (
+        select(
+            Booking,
+            GameSession.title.label("session_title"),
+            GameSession.scheduled_start,
+            GameSession.scheduled_end,
+            GameSession.exhibition_id,
+            Exhibition.title.label("exhibition_title"),
+            Zone.name.label("zone_name"),
+            PhysicalTable.label.label("table_label"),
+            User.full_name.label("gm_name"),
+        )
+        .join(GameSession, Booking.game_session_id == GameSession.id)
+        .join(Exhibition, GameSession.exhibition_id == Exhibition.id)
+        .join(User, GameSession.created_by_user_id == User.id)
+        .outerjoin(PhysicalTable, GameSession.physical_table_id == PhysicalTable.id)
+        .outerjoin(Zone, PhysicalTable.zone_id == Zone.id)
+        .where(Booking.user_id == current_user.id)
+        .order_by(GameSession.scheduled_start)
+    )
+
+    if exhibition_id:
+        query = query.where(GameSession.exhibition_id == exhibition_id)
+
+    result = await db.execute(query)
+    rows = result.all()
+
+    bookings = []
+    for row in rows:
+        booking = row[0]
+        bookings.append(MyBookingSummary(
+            id=booking.id,
+            game_session_id=booking.game_session_id,
+            session_title=row[1],
+            exhibition_id=row[4],
+            exhibition_title=row[5],
+            status=booking.status,
+            role=booking.role,
+            scheduled_start=row[2],
+            scheduled_end=row[3],
+            zone_name=row[6],
+            table_label=row[7],
+            gm_name=row[8],
+        ))
+
+    return bookings
+
+
+@router.get("/me/agenda/{exhibition_id}", response_model=UserAgenda)
+async def get_my_agenda(
+    exhibition_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Get combined agenda for an exhibition (JS.B6).
+
+    Returns all sessions (as GM) and bookings (as player) with
+    conflict detection for overlapping schedules.
+    """
+    # Get exhibition
+    exhibition_result = await db.execute(
+        select(Exhibition).where(Exhibition.id == exhibition_id)
+    )
+    exhibition = exhibition_result.scalar_one_or_none()
+    if not exhibition:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Exhibition not found",
+        )
+
+    # Get my sessions
+    sessions_query = (
+        select(
+            GameSession,
+            Zone.name.label("zone_name"),
+            PhysicalTable.label.label("table_label"),
+        )
+        .outerjoin(PhysicalTable, GameSession.physical_table_id == PhysicalTable.id)
+        .outerjoin(Zone, PhysicalTable.zone_id == Zone.id)
+        .where(
+            GameSession.created_by_user_id == current_user.id,
+            GameSession.exhibition_id == exhibition_id,
+            GameSession.status.notin_([SessionStatus.CANCELLED, SessionStatus.REJECTED]),
+        )
+        .order_by(GameSession.scheduled_start)
+    )
+    sessions_result = await db.execute(sessions_query)
+    session_rows = sessions_result.all()
+
+    my_sessions = []
+    session_times = []  # For conflict detection
+
+    for row in session_rows:
+        session = row[0]
+
+        # Count bookings
+        booking_counts = await db.execute(
+            select(
+                Booking.status,
+                func.count(Booking.id),
+            )
+            .where(Booking.game_session_id == session.id)
+            .group_by(Booking.status)
+        )
+        counts = {r[0]: r[1] for r in booking_counts.fetchall()}
+        confirmed = counts.get(BookingStatus.CONFIRMED, 0) + counts.get(BookingStatus.CHECKED_IN, 0)
+        waitlist = counts.get(BookingStatus.WAITING_LIST, 0)
+
+        my_sessions.append(MySessionSummary(
+            id=session.id,
+            title=session.title,
+            exhibition_id=session.exhibition_id,
+            exhibition_title=exhibition.title,
+            status=session.status,
+            scheduled_start=session.scheduled_start,
+            scheduled_end=session.scheduled_end,
+            zone_name=row[1],
+            table_label=row[2],
+            max_players_count=session.max_players_count,
+            confirmed_players=confirmed,
+            waitlist_count=waitlist,
+        ))
+
+        session_times.append({
+            "type": "gm",
+            "title": session.title,
+            "start": session.scheduled_start,
+            "end": session.scheduled_end,
+        })
+
+    # Get my bookings
+    bookings_query = (
+        select(
+            Booking,
+            GameSession.title.label("session_title"),
+            GameSession.scheduled_start,
+            GameSession.scheduled_end,
+            Zone.name.label("zone_name"),
+            PhysicalTable.label.label("table_label"),
+            User.full_name.label("gm_name"),
+        )
+        .join(GameSession, Booking.game_session_id == GameSession.id)
+        .join(User, GameSession.created_by_user_id == User.id)
+        .outerjoin(PhysicalTable, GameSession.physical_table_id == PhysicalTable.id)
+        .outerjoin(Zone, PhysicalTable.zone_id == Zone.id)
+        .where(
+            Booking.user_id == current_user.id,
+            GameSession.exhibition_id == exhibition_id,
+            Booking.status.in_([
+                BookingStatus.CONFIRMED,
+                BookingStatus.CHECKED_IN,
+                BookingStatus.WAITING_LIST,
+            ]),
+        )
+        .order_by(GameSession.scheduled_start)
+    )
+    bookings_result = await db.execute(bookings_query)
+    booking_rows = bookings_result.all()
+
+    my_bookings = []
+    for row in booking_rows:
+        booking = row[0]
+        my_bookings.append(MyBookingSummary(
+            id=booking.id,
+            game_session_id=booking.game_session_id,
+            session_title=row[1],
+            exhibition_id=exhibition_id,
+            exhibition_title=exhibition.title,
+            status=booking.status,
+            role=booking.role,
+            scheduled_start=row[2],
+            scheduled_end=row[3],
+            zone_name=row[4],
+            table_label=row[5],
+            gm_name=row[6],
+        ))
+
+        session_times.append({
+            "type": "player",
+            "title": row[1],
+            "start": row[2],
+            "end": row[3],
+        })
+
+    # Detect conflicts
+    conflicts = []
+    for i, t1 in enumerate(session_times):
+        for t2 in session_times[i + 1:]:
+            # Check overlap
+            if t1["start"] < t2["end"] and t1["end"] > t2["start"]:
+                conflicts.append(
+                    f"Conflict: '{t1['title']}' ({t1['type']}) overlaps with "
+                    f"'{t2['title']}' ({t2['type']})"
+                )
+
+    return UserAgenda(
+        user_id=current_user.id,
+        exhibition_id=exhibition_id,
+        exhibition_title=exhibition.title,
+        my_sessions=my_sessions,
+        my_bookings=my_bookings,
+        conflicts=conflicts,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@ FastAPI application entry point.
 """
 from fastapi import FastAPI
 
-from app.api.v1.endpoint import admin, auth, exhibition, organization, zone, game_session, operations
+from app.api.v1.endpoint import admin, auth, exhibition, organization, zone, game_session, operations, user
 
 app = FastAPI(
     title="Structura Ludis API",
@@ -46,6 +46,11 @@ app.include_router(
     operations.router,
     prefix="/api/v1/ops",
     tags=["Operations"],
+)
+app.include_router(
+    user.router,
+    prefix="/api/v1/users",
+    tags=["Users"],
 )
 
 

--- a/backend/tests/api/v1/test_user.py
+++ b/backend/tests/api/v1/test_user.py
@@ -1,0 +1,387 @@
+"""
+Tests for User API endpoints (JS.B6 - Agenda Management).
+"""
+import pytest
+from uuid import uuid4
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.game.entity import GameCategory, Game
+from app.domain.shared.entity import GameComplexity
+
+
+@pytest.fixture
+async def test_game_category(db_session: AsyncSession) -> dict:
+    """Create a test game category."""
+    category = GameCategory(
+        id=uuid4(),
+        name="Role-Playing Games",
+        slug="rpg",
+    )
+    db_session.add(category)
+    await db_session.commit()
+    await db_session.refresh(category)
+
+    return {
+        "id": str(category.id),
+        "name": category.name,
+        "slug": category.slug,
+    }
+
+
+@pytest.fixture
+async def test_game(db_session: AsyncSession, test_game_category: dict) -> dict:
+    """Create a test game."""
+    game = Game(
+        id=uuid4(),
+        category_id=test_game_category["id"],
+        title="Dungeons & Dragons 5e",
+        publisher="Wizards of the Coast",
+        complexity=GameComplexity.INTERMEDIATE,
+        min_players=3,
+        max_players=6,
+    )
+    db_session.add(game)
+    await db_session.commit()
+    await db_session.refresh(game)
+
+    return {
+        "id": str(game.id),
+        "title": game.title,
+        "category_id": test_game_category["id"],
+    }
+
+
+@pytest.fixture
+async def test_exhibition_with_slot(auth_client: AsyncClient, test_organizer: dict) -> dict:
+    """Create an exhibition with a time slot."""
+    exhibition_payload = {
+        "title": "User Test Convention",
+        "slug": "user-test-convention",
+        "start_date": "2026-07-01T08:00:00Z",
+        "end_date": "2026-07-03T22:00:00Z",
+        "organization_id": test_organizer["organization_id"],
+    }
+    exhibition_resp = await auth_client.post("/api/v1/exhibitions/", json=exhibition_payload)
+    exhibition_id = exhibition_resp.json()["id"]
+
+    slot_payload = {
+        "name": "Afternoon",
+        "start_time": "2026-07-01T14:00:00Z",
+        "end_time": "2026-07-01T18:00:00Z",
+        "max_duration_minutes": 240,
+        "buffer_time_minutes": 15,
+    }
+    slot_resp = await auth_client.post(
+        f"/api/v1/exhibitions/{exhibition_id}/slots", json=slot_payload
+    )
+
+    return {
+        "exhibition_id": exhibition_id,
+        "time_slot_id": slot_resp.json()["id"],
+    }
+
+
+class TestUserProfile:
+    """Tests for user profile endpoints."""
+
+    async def test_get_current_user(self, auth_client: AsyncClient):
+        """Get current user returns profile."""
+        response = await auth_client.get("/api/v1/users/me")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "id" in data
+        assert "email" in data
+
+    async def test_get_current_user_unauthorized(self, client: AsyncClient):
+        """Get current user without auth returns 401."""
+        response = await client.get("/api/v1/users/me")
+
+        assert response.status_code == 401
+
+    async def test_update_profile(self, auth_client: AsyncClient):
+        """Update current user profile."""
+        response = await auth_client.put(
+            "/api/v1/users/me",
+            json={"full_name": "Updated Name", "locale": "fr"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["full_name"] == "Updated Name"
+        assert data["locale"] == "fr"
+
+
+class TestMySessionsList:
+    """Tests for listing user's sessions (as GM)."""
+
+    async def test_list_my_sessions_empty(
+        self,
+        auth_client: AsyncClient,
+    ):
+        """List returns empty when no sessions."""
+        response = await auth_client.get("/api/v1/users/me/sessions")
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    async def test_list_my_sessions(
+        self,
+        auth_client: AsyncClient,
+        test_exhibition_with_slot: dict,
+        test_game: dict,
+    ):
+        """List returns sessions created by user."""
+        # Create a session
+        payload = {
+            "title": "My GM Session",
+            "exhibition_id": test_exhibition_with_slot["exhibition_id"],
+            "time_slot_id": test_exhibition_with_slot["time_slot_id"],
+            "game_id": test_game["id"],
+            "max_players_count": 5,
+            "scheduled_start": "2026-07-01T14:00:00Z",
+            "scheduled_end": "2026-07-01T17:00:00Z",
+        }
+        await auth_client.post("/api/v1/sessions/", json=payload)
+
+        response = await auth_client.get("/api/v1/users/me/sessions")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["title"] == "My GM Session"
+        assert "exhibition_title" in data[0]
+        assert "confirmed_players" in data[0]
+        assert "waitlist_count" in data[0]
+
+    async def test_list_my_sessions_filter_exhibition(
+        self,
+        auth_client: AsyncClient,
+        test_exhibition_with_slot: dict,
+        test_game: dict,
+    ):
+        """List can filter by exhibition."""
+        # Create a session
+        payload = {
+            "title": "Filtered Session",
+            "exhibition_id": test_exhibition_with_slot["exhibition_id"],
+            "time_slot_id": test_exhibition_with_slot["time_slot_id"],
+            "game_id": test_game["id"],
+            "max_players_count": 5,
+            "scheduled_start": "2026-07-01T14:00:00Z",
+            "scheduled_end": "2026-07-01T17:00:00Z",
+        }
+        await auth_client.post("/api/v1/sessions/", json=payload)
+
+        # Filter by correct exhibition
+        response = await auth_client.get(
+            "/api/v1/users/me/sessions",
+            params={"exhibition_id": test_exhibition_with_slot["exhibition_id"]},
+        )
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+
+        # Filter by wrong exhibition
+        response2 = await auth_client.get(
+            "/api/v1/users/me/sessions",
+            params={"exhibition_id": "00000000-0000-0000-0000-000000000000"},
+        )
+        assert response2.status_code == 200
+        assert len(response2.json()) == 0
+
+
+class TestMyBookingsList:
+    """Tests for listing user's bookings (as player)."""
+
+    async def _create_validated_session(
+        self,
+        auth_client: AsyncClient,
+        exhibition_id: str,
+        time_slot_id: str,
+        game_id: str,
+    ) -> str:
+        """Helper to create a validated session."""
+        payload = {
+            "title": "Bookable Session",
+            "exhibition_id": exhibition_id,
+            "time_slot_id": time_slot_id,
+            "game_id": game_id,
+            "max_players_count": 5,
+            "scheduled_start": "2026-07-01T14:00:00Z",
+            "scheduled_end": "2026-07-01T17:00:00Z",
+        }
+        create_resp = await auth_client.post("/api/v1/sessions/", json=payload)
+        session_id = create_resp.json()["id"]
+
+        await auth_client.post(f"/api/v1/sessions/{session_id}/submit")
+        await auth_client.post(
+            f"/api/v1/sessions/{session_id}/moderate",
+            json={"action": "approve"},
+        )
+
+        return session_id
+
+    async def test_list_my_bookings_empty(
+        self,
+        auth_client: AsyncClient,
+    ):
+        """List returns empty when no bookings."""
+        response = await auth_client.get("/api/v1/users/me/bookings")
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    async def test_list_my_bookings(
+        self,
+        auth_client: AsyncClient,
+        test_exhibition_with_slot: dict,
+        test_game: dict,
+    ):
+        """List returns bookings for user."""
+        session_id = await self._create_validated_session(
+            auth_client,
+            test_exhibition_with_slot["exhibition_id"],
+            test_exhibition_with_slot["time_slot_id"],
+            test_game["id"],
+        )
+
+        # Book the session
+        await auth_client.post(
+            f"/api/v1/sessions/{session_id}/bookings",
+            json={"role": "PLAYER"},
+        )
+
+        response = await auth_client.get("/api/v1/users/me/bookings")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["session_title"] == "Bookable Session"
+        assert "exhibition_title" in data[0]
+        assert "gm_name" in data[0]
+
+
+class TestUserAgenda:
+    """Tests for user agenda endpoint (JS.B6)."""
+
+    async def _create_validated_session(
+        self,
+        auth_client: AsyncClient,
+        exhibition_id: str,
+        time_slot_id: str,
+        game_id: str,
+        title: str,
+        start: str,
+        end: str,
+    ) -> str:
+        """Helper to create a validated session."""
+        payload = {
+            "title": title,
+            "exhibition_id": exhibition_id,
+            "time_slot_id": time_slot_id,
+            "game_id": game_id,
+            "max_players_count": 5,
+            "scheduled_start": start,
+            "scheduled_end": end,
+        }
+        create_resp = await auth_client.post("/api/v1/sessions/", json=payload)
+        session_id = create_resp.json()["id"]
+
+        await auth_client.post(f"/api/v1/sessions/{session_id}/submit")
+        await auth_client.post(
+            f"/api/v1/sessions/{session_id}/moderate",
+            json={"action": "approve"},
+        )
+
+        return session_id
+
+    async def test_get_agenda(
+        self,
+        auth_client: AsyncClient,
+        test_exhibition_with_slot: dict,
+        test_game: dict,
+    ):
+        """Get agenda returns sessions and bookings."""
+        # Create a session as GM
+        payload = {
+            "title": "My GM Session",
+            "exhibition_id": test_exhibition_with_slot["exhibition_id"],
+            "time_slot_id": test_exhibition_with_slot["time_slot_id"],
+            "game_id": test_game["id"],
+            "max_players_count": 5,
+            "scheduled_start": "2026-07-01T14:00:00Z",
+            "scheduled_end": "2026-07-01T15:00:00Z",
+        }
+        await auth_client.post("/api/v1/sessions/", json=payload)
+
+        response = await auth_client.get(
+            f"/api/v1/users/me/agenda/{test_exhibition_with_slot['exhibition_id']}"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["exhibition_title"] == "User Test Convention"
+        assert len(data["my_sessions"]) == 1
+        assert data["my_sessions"][0]["title"] == "My GM Session"
+        assert "conflicts" in data
+
+    async def test_agenda_exhibition_not_found(
+        self,
+        auth_client: AsyncClient,
+    ):
+        """Agenda for non-existent exhibition returns 404."""
+        fake_id = "00000000-0000-0000-0000-000000000000"
+
+        response = await auth_client.get(f"/api/v1/users/me/agenda/{fake_id}")
+
+        assert response.status_code == 404
+
+    async def test_agenda_detects_conflicts(
+        self,
+        auth_client: AsyncClient,
+        second_auth_client: AsyncClient,
+        test_exhibition_with_slot: dict,
+        test_game: dict,
+    ):
+        """Agenda detects overlapping schedules."""
+        # Create a session as GM (14:00-15:30)
+        gm_session = {
+            "title": "GM Session",
+            "exhibition_id": test_exhibition_with_slot["exhibition_id"],
+            "time_slot_id": test_exhibition_with_slot["time_slot_id"],
+            "game_id": test_game["id"],
+            "max_players_count": 5,
+            "scheduled_start": "2026-07-01T14:00:00Z",
+            "scheduled_end": "2026-07-01T15:30:00Z",
+        }
+        await auth_client.post("/api/v1/sessions/", json=gm_session)
+
+        # Create another session by different GM (15:00-17:00)
+        player_session_id = await self._create_validated_session(
+            second_auth_client,
+            test_exhibition_with_slot["exhibition_id"],
+            test_exhibition_with_slot["time_slot_id"],
+            test_game["id"],
+            "Player Session",
+            "2026-07-01T15:00:00Z",
+            "2026-07-01T17:00:00Z",
+        )
+
+        # Book as player (this overlaps with GM session)
+        await auth_client.post(
+            f"/api/v1/sessions/{player_session_id}/bookings",
+            json={"role": "PLAYER"},
+        )
+
+        # Get agenda - should show conflict
+        response = await auth_client.get(
+            f"/api/v1/users/me/agenda/{test_exhibition_with_slot['exhibition_id']}"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["my_sessions"]) == 1
+        assert len(data["my_bookings"]) == 1
+        assert len(data["conflicts"]) > 0
+        assert "overlaps" in data["conflicts"][0].lower()


### PR DESCRIPTION
## Summary
- Add user profile endpoints (`GET /users/me`, `PUT /users/me`)
- Add session listing for GMs (`GET /users/me/sessions`)
- Add booking listing for players (`GET /users/me/bookings`)
- Add combined agenda with conflict detection (`GET /users/me/agenda/{exhibition_id}`)

## Features
- Session summaries include booking counts (confirmed players, waitlist)
- Booking summaries include GM name, zone and table information
- Automatic detection of schedule overlaps between GM sessions and player bookings
- Filter sessions and bookings by exhibition_id

## Test plan
- [x] Test profile retrieval and update
- [x] Test sessions list (empty, with data, filtered)
- [x] Test bookings list (empty, with data)
- [x] Test agenda endpoint (normal case, exhibition not found)
- [x] Test conflict detection for overlapping schedules
- [x] All 161 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)