### PR TITLE
Add session cancellation with player notification (JS.B4)

### DIFF
--- a/backend/app/domain/game/schemas.py
+++ b/backend/app/domain/game/schemas.py
@@ -269,3 +269,37 @@ class SessionSearchResult(GameSessionRead):
     game_title: Optional[str] = Field(
         None, description="Game title for display"
     )
+
+
+# =============================================================================
+# Session Cancellation Schemas (JS.B4)
+# =============================================================================
+
+class SessionCancelRequest(BaseModel):
+    """Schema for cancelling a session."""
+    reason: str = Field(
+        ...,
+        min_length=1,
+        max_length=1000,
+        description="Reason for cancellation (will be sent to registered players)"
+    )
+
+
+class AffectedUser(BaseModel):
+    """User affected by a cancellation."""
+    user_id: UUID
+    email: str
+    full_name: Optional[str] = None
+    booking_status: BookingStatus
+
+
+class SessionCancellationResult(BaseModel):
+    """Result of a session cancellation."""
+    session: GameSessionRead
+    affected_users: List[AffectedUser] = Field(
+        default_factory=list,
+        description="Users who were notified of the cancellation"
+    )
+    notifications_sent: int = Field(
+        0, description="Number of notifications sent"
+    )

--- a/backend/app/services/notification.py
+++ b/backend/app/services/notification.py
@@ -1,0 +1,145 @@
+"""
+Notification service layer.
+
+Handles sending notifications to users (email, push, etc.).
+This is a stub implementation that logs notifications for now.
+"""
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationType(str, Enum):
+    """Types of notifications."""
+    SESSION_CANCELLED = "session_cancelled"
+    SESSION_REMINDER = "session_reminder"
+    BOOKING_CONFIRMED = "booking_confirmed"
+    BOOKING_CANCELLED = "booking_cancelled"
+    WAITLIST_PROMOTED = "waitlist_promoted"
+
+
+@dataclass
+class NotificationRecipient:
+    """Recipient of a notification."""
+    user_id: UUID
+    email: str
+    full_name: Optional[str] = None
+
+
+@dataclass
+class NotificationPayload:
+    """Payload for a notification."""
+    notification_type: NotificationType
+    session_id: UUID
+    session_title: str
+    exhibition_title: str
+    scheduled_start: datetime
+    scheduled_end: datetime
+    cancellation_reason: Optional[str] = None
+    gm_name: Optional[str] = None
+
+
+class NotificationService:
+    """
+    Service for sending notifications to users.
+
+    This is a stub implementation that logs notifications.
+    In production, this would integrate with:
+    - Email service (SendGrid, AWS SES, etc.)
+    - Push notifications (Firebase, etc.)
+    - In-app notifications (WebSocket/SSE)
+    """
+
+    async def notify_session_cancelled(
+        self,
+        recipients: List[NotificationRecipient],
+        payload: NotificationPayload,
+    ) -> int:
+        """
+        Notify users that a session has been cancelled.
+
+        Args:
+            recipients: List of users to notify
+            payload: Notification details
+
+        Returns:
+            Number of notifications sent
+        """
+        for recipient in recipients:
+            logger.info(
+                "NOTIFICATION [%s] to %s <%s>: Session '%s' scheduled for %s has been cancelled. Reason: %s",
+                payload.notification_type.value,
+                recipient.full_name or "User",
+                recipient.email,
+                payload.session_title,
+                payload.scheduled_start.isoformat(),
+                payload.cancellation_reason or "Not specified",
+            )
+
+        # TODO: Implement actual notification sending
+        # - Queue emails for batch sending
+        # - Send push notifications
+        # - Create in-app notification records
+
+        return len(recipients)
+
+    async def notify_waitlist_promoted(
+        self,
+        recipient: NotificationRecipient,
+        payload: NotificationPayload,
+    ) -> bool:
+        """
+        Notify a user that they've been promoted from waitlist.
+
+        Args:
+            recipient: User to notify
+            payload: Notification details
+
+        Returns:
+            True if notification was sent
+        """
+        logger.info(
+            "NOTIFICATION [%s] to %s <%s>: You've been promoted from waitlist for session '%s' on %s!",
+            NotificationType.WAITLIST_PROMOTED.value,
+            recipient.full_name or "User",
+            recipient.email,
+            payload.session_title,
+            payload.scheduled_start.isoformat(),
+        )
+
+        # TODO: Implement actual notification sending
+
+        return True
+
+    async def notify_booking_confirmed(
+        self,
+        recipient: NotificationRecipient,
+        payload: NotificationPayload,
+    ) -> bool:
+        """
+        Notify a user that their booking is confirmed.
+
+        Args:
+            recipient: User to notify
+            payload: Notification details
+
+        Returns:
+            True if notification was sent
+        """
+        logger.info(
+            "NOTIFICATION [%s] to %s <%s>: Booking confirmed for session '%s' on %s",
+            NotificationType.BOOKING_CONFIRMED.value,
+            recipient.full_name or "User",
+            recipient.email,
+            payload.session_title,
+            payload.scheduled_start.isoformat(),
+        )
+
+        # TODO: Implement actual notification sending
+
+        return True

--- a/backend/tests/api/v1/test_operations.py
+++ b/backend/tests/api/v1/test_operations.py
@@ -218,8 +218,11 @@ class TestAutoCancel:
         assert response.status_code == 200
         cancelled = response.json()
         assert len(cancelled) == 1
-        assert cancelled[0]["id"] == session_id
-        assert cancelled[0]["status"] == "CANCELLED"
+        # Response is now SessionCancellationResult with nested session
+        assert cancelled[0]["session"]["id"] == session_id
+        assert cancelled[0]["session"]["status"] == "CANCELLED"
+        assert "affected_users" in cancelled[0]
+        assert "notifications_sent" in cancelled[0]
 
     async def test_auto_cancel_does_not_affect_checked_in_sessions(
         self,


### PR DESCRIPTION
Implements session cancellation functionality:
- POST /sessions/{id}/cancel - Cancel a session with reason
- Cancels all associated bookings (confirmed, waitlist)
- Returns list of affected users for notification
- Updates auto-cancellation to also notify players

New notification service (stub):
- NotificationService with methods for session cancellation, waitlist promotion
- Logs notifications for now, ready for email/push integration

Features:
- GM, organizers, and super admins can cancel sessions
- Cannot cancel already cancelled or finished sessions
- Affected users receive notification with cancellation reason
- Auto-cancel endpoint now returns SessionCancellationResult with affected users

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
