### PR TITLE
Add partner team management endpoints

### DIFF
--- a/backend/app/api/v1/endpoint/group.py
+++ b/backend/app/api/v1/endpoint/group.py
@@ -1,0 +1,518 @@
+"""
+UserGroup API endpoints (#31).
+
+Group management and member administration for partners.
+"""
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.domain.organization.entity import Organization, UserGroup
+from app.domain.organization.schemas import (
+    UserGroupCreate,
+    UserGroupRead,
+    UserGroupUpdate,
+    GroupMemberAdd,
+    GroupMemberUpdate,
+    GroupMemberRead,
+)
+from app.domain.user.entity import User, UserGroupMembership
+from app.domain.shared.entity import GlobalRole, GroupRole
+from app.api.deps import get_current_active_user
+
+router = APIRouter()
+
+
+# =============================================================================
+# UserGroup CRUD
+# =============================================================================
+
+@router.get("/", response_model=List[UserGroupRead])
+async def list_groups(
+    organization_id: UUID = None,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    List user groups.
+
+    Optional filter by organization_id.
+    """
+    query = select(UserGroup)
+    if organization_id:
+        query = query.where(UserGroup.organization_id == organization_id)
+    query = query.order_by(UserGroup.name)
+
+    result = await db.execute(query)
+    return result.scalars().all()
+
+
+@router.post("/", response_model=UserGroupRead, status_code=status.HTTP_201_CREATED)
+async def create_group(
+    group_in: UserGroupCreate,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Create a new user group.
+
+    Requires: Organizer or SUPER_ADMIN.
+    """
+    if current_user.global_role not in [GlobalRole.SUPER_ADMIN, GlobalRole.ORGANIZER]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only organizers can create groups",
+        )
+
+    # Verify organization exists
+    org_result = await db.execute(
+        select(Organization).where(Organization.id == group_in.organization_id)
+    )
+    if not org_result.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organization not found",
+        )
+
+    group = UserGroup(**group_in.model_dump())
+    db.add(group)
+    await db.flush()
+    await db.refresh(group)
+
+    return group
+
+
+@router.get("/{group_id}", response_model=UserGroupRead)
+async def get_group(
+    group_id: UUID,
+    db: AsyncSession = Depends(get_db),
+):
+    """Get a user group by ID."""
+    result = await db.execute(
+        select(UserGroup).where(UserGroup.id == group_id)
+    )
+    group = result.scalar_one_or_none()
+
+    if not group:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Group not found",
+        )
+
+    return group
+
+
+@router.put("/{group_id}", response_model=UserGroupRead)
+async def update_group(
+    group_id: UUID,
+    group_in: UserGroupUpdate,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Update a user group.
+
+    Requires: Organizer, SUPER_ADMIN, or group OWNER/ADMIN.
+    """
+    result = await db.execute(
+        select(UserGroup).where(UserGroup.id == group_id)
+    )
+    group = result.scalar_one_or_none()
+
+    if not group:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Group not found",
+        )
+
+    # Check permissions
+    can_update = current_user.global_role in [GlobalRole.SUPER_ADMIN, GlobalRole.ORGANIZER]
+
+    if not can_update:
+        # Check if user is group admin/owner
+        membership_result = await db.execute(
+            select(UserGroupMembership).where(
+                UserGroupMembership.user_group_id == group_id,
+                UserGroupMembership.user_id == current_user.id,
+                UserGroupMembership.group_role.in_([GroupRole.OWNER, GroupRole.ADMIN]),
+            )
+        )
+        if membership_result.scalar_one_or_none():
+            can_update = True
+
+    if not can_update:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You cannot update this group",
+        )
+
+    update_data = group_in.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(group, field, value)
+
+    await db.flush()
+    await db.refresh(group)
+
+    return group
+
+
+@router.delete("/{group_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_group(
+    group_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Delete a user group.
+
+    Requires: Organizer or SUPER_ADMIN.
+    """
+    if current_user.global_role not in [GlobalRole.SUPER_ADMIN, GlobalRole.ORGANIZER]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only organizers can delete groups",
+        )
+
+    result = await db.execute(
+        select(UserGroup).where(UserGroup.id == group_id)
+    )
+    group = result.scalar_one_or_none()
+
+    if not group:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Group not found",
+        )
+
+    await db.delete(group)
+
+
+# =============================================================================
+# Group Members Management (#31)
+# =============================================================================
+
+@router.get("/{group_id}/members", response_model=List[GroupMemberRead])
+async def list_group_members(
+    group_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    List all members of a group.
+
+    Visible to: group members, organizers, or SUPER_ADMIN.
+    """
+    # Check group exists
+    group_result = await db.execute(
+        select(UserGroup).where(UserGroup.id == group_id)
+    )
+    group = group_result.scalar_one_or_none()
+
+    if not group:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Group not found",
+        )
+
+    # Check permissions (public groups visible to all, private to members/admins)
+    can_view = (
+        group.is_public
+        or current_user.global_role in [GlobalRole.SUPER_ADMIN, GlobalRole.ORGANIZER]
+    )
+
+    if not can_view:
+        # Check if user is a member
+        membership_check = await db.execute(
+            select(UserGroupMembership.id).where(
+                UserGroupMembership.user_group_id == group_id,
+                UserGroupMembership.user_id == current_user.id,
+            )
+        )
+        if membership_check.scalar_one_or_none():
+            can_view = True
+
+    if not can_view:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You cannot view members of this group",
+        )
+
+    # Fetch members with user info
+    result = await db.execute(
+        select(UserGroupMembership, User.email, User.full_name)
+        .join(User, UserGroupMembership.user_id == User.id)
+        .where(UserGroupMembership.user_group_id == group_id)
+        .order_by(UserGroupMembership.joined_at)
+    )
+    rows = result.all()
+
+    return [
+        GroupMemberRead(
+            id=membership.id,
+            user_id=membership.user_id,
+            user_email=email,
+            user_full_name=full_name,
+            group_role=membership.group_role,
+            joined_at=membership.joined_at,
+        )
+        for membership, email, full_name in rows
+    ]
+
+
+@router.post("/{group_id}/members", response_model=GroupMemberRead, status_code=status.HTTP_201_CREATED)
+async def add_group_member(
+    group_id: UUID,
+    member_in: GroupMemberAdd,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Add a member to a group.
+
+    Requires: Organizer, SUPER_ADMIN, or group OWNER/ADMIN.
+    """
+    # Check group exists
+    group_result = await db.execute(
+        select(UserGroup).where(UserGroup.id == group_id)
+    )
+    if not group_result.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Group not found",
+        )
+
+    # Check permissions
+    can_add = current_user.global_role in [GlobalRole.SUPER_ADMIN, GlobalRole.ORGANIZER]
+
+    if not can_add:
+        membership_result = await db.execute(
+            select(UserGroupMembership).where(
+                UserGroupMembership.user_group_id == group_id,
+                UserGroupMembership.user_id == current_user.id,
+                UserGroupMembership.group_role.in_([GroupRole.OWNER, GroupRole.ADMIN]),
+            )
+        )
+        if membership_result.scalar_one_or_none():
+            can_add = True
+
+    if not can_add:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You cannot add members to this group",
+        )
+
+    # Check user exists
+    user_result = await db.execute(
+        select(User).where(User.id == member_in.user_id)
+    )
+    user = user_result.scalar_one_or_none()
+
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+
+    # Check if already a member
+    existing = await db.execute(
+        select(UserGroupMembership).where(
+            UserGroupMembership.user_group_id == group_id,
+            UserGroupMembership.user_id == member_in.user_id,
+        )
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="User is already a member of this group",
+        )
+
+    # Create membership
+    membership = UserGroupMembership(
+        user_group_id=group_id,
+        user_id=member_in.user_id,
+        group_role=member_in.group_role,
+    )
+    db.add(membership)
+    await db.flush()
+    await db.refresh(membership)
+
+    return GroupMemberRead(
+        id=membership.id,
+        user_id=membership.user_id,
+        user_email=user.email,
+        user_full_name=user.full_name,
+        group_role=membership.group_role,
+        joined_at=membership.joined_at,
+    )
+
+
+@router.patch("/{group_id}/members/{user_id}", response_model=GroupMemberRead)
+async def update_group_member(
+    group_id: UUID,
+    user_id: UUID,
+    member_in: GroupMemberUpdate,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Update a member's role in a group.
+
+    Requires: Organizer, SUPER_ADMIN, or group OWNER.
+    Cannot demote yourself if you're the only OWNER.
+    """
+    # Check group exists
+    group_result = await db.execute(
+        select(UserGroup).where(UserGroup.id == group_id)
+    )
+    if not group_result.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Group not found",
+        )
+
+    # Get membership
+    membership_result = await db.execute(
+        select(UserGroupMembership, User.email, User.full_name)
+        .join(User, UserGroupMembership.user_id == User.id)
+        .where(
+            UserGroupMembership.user_group_id == group_id,
+            UserGroupMembership.user_id == user_id,
+        )
+    )
+    row = membership_result.one_or_none()
+
+    if not row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Member not found in this group",
+        )
+
+    membership, email, full_name = row
+
+    # Check permissions - only OWNER can change roles
+    can_update = current_user.global_role in [GlobalRole.SUPER_ADMIN, GlobalRole.ORGANIZER]
+
+    if not can_update:
+        owner_check = await db.execute(
+            select(UserGroupMembership).where(
+                UserGroupMembership.user_group_id == group_id,
+                UserGroupMembership.user_id == current_user.id,
+                UserGroupMembership.group_role == GroupRole.OWNER,
+            )
+        )
+        if owner_check.scalar_one_or_none():
+            can_update = True
+
+    if not can_update:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only group owners can change member roles",
+        )
+
+    # Prevent demoting the last owner
+    if membership.group_role == GroupRole.OWNER and member_in.group_role != GroupRole.OWNER:
+        owner_count = await db.execute(
+            select(UserGroupMembership).where(
+                UserGroupMembership.user_group_id == group_id,
+                UserGroupMembership.group_role == GroupRole.OWNER,
+            )
+        )
+        if len(owner_count.scalars().all()) <= 1:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Cannot demote the last owner of a group",
+            )
+
+    membership.group_role = member_in.group_role
+    await db.flush()
+    await db.refresh(membership)
+
+    return GroupMemberRead(
+        id=membership.id,
+        user_id=membership.user_id,
+        user_email=email,
+        user_full_name=full_name,
+        group_role=membership.group_role,
+        joined_at=membership.joined_at,
+    )
+
+
+@router.delete("/{group_id}/members/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_group_member(
+    group_id: UUID,
+    user_id: UUID,
+    current_user: User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Remove a member from a group.
+
+    Requires: Organizer, SUPER_ADMIN, group OWNER/ADMIN, or self-removal.
+    Cannot remove the last OWNER.
+    """
+    # Check group exists
+    group_result = await db.execute(
+        select(UserGroup).where(UserGroup.id == group_id)
+    )
+    if not group_result.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Group not found",
+        )
+
+    # Get membership
+    membership_result = await db.execute(
+        select(UserGroupMembership).where(
+            UserGroupMembership.user_group_id == group_id,
+            UserGroupMembership.user_id == user_id,
+        )
+    )
+    membership = membership_result.scalar_one_or_none()
+
+    if not membership:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Member not found in this group",
+        )
+
+    # Check permissions
+    can_remove = (
+        current_user.global_role in [GlobalRole.SUPER_ADMIN, GlobalRole.ORGANIZER]
+        or user_id == current_user.id  # Self-removal
+    )
+
+    if not can_remove:
+        admin_check = await db.execute(
+            select(UserGroupMembership).where(
+                UserGroupMembership.user_group_id == group_id,
+                UserGroupMembership.user_id == current_user.id,
+                UserGroupMembership.group_role.in_([GroupRole.OWNER, GroupRole.ADMIN]),
+            )
+        )
+        if admin_check.scalar_one_or_none():
+            can_remove = True
+
+    if not can_remove:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You cannot remove members from this group",
+        )
+
+    # Prevent removing the last owner
+    if membership.group_role == GroupRole.OWNER:
+        owner_count = await db.execute(
+            select(UserGroupMembership).where(
+                UserGroupMembership.user_group_id == group_id,
+                UserGroupMembership.group_role == GroupRole.OWNER,
+            )
+        )
+        if len(owner_count.scalars().all()) <= 1:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Cannot remove the last owner of a group",
+            )
+
+    await db.delete(membership)

--- a/backend/app/domain/organization/schemas.py
+++ b/backend/app/domain/organization/schemas.py
@@ -2,11 +2,17 @@
 Organization domain schemas (DTOs).
 """
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
+from app.domain.shared.entity import UserGroupType, GroupRole
+
+
+# =============================================================================
+# Organization Schemas
+# =============================================================================
 
 class OrganizationBase(BaseModel):
     """Base schema with common fields."""
@@ -35,3 +41,68 @@ class OrganizationRead(OrganizationBase):
     updated_at: Optional[datetime] = None
 
     model_config = ConfigDict(from_attributes=True)
+
+
+# =============================================================================
+# UserGroup Schemas
+# =============================================================================
+
+class UserGroupBase(BaseModel):
+    """Base schema for user groups."""
+    name: str = Field(..., min_length=1, max_length=255)
+    type: UserGroupType = Field(default=UserGroupType.ASSOCIATION)
+    is_public: bool = Field(default=False)
+
+
+class UserGroupCreate(UserGroupBase):
+    """Schema for creating a user group."""
+    organization_id: UUID
+
+
+class UserGroupUpdate(BaseModel):
+    """Schema for updating a user group."""
+    name: Optional[str] = Field(None, min_length=1, max_length=255)
+    type: Optional[UserGroupType] = None
+    is_public: Optional[bool] = None
+
+
+class UserGroupRead(UserGroupBase):
+    """Schema for reading a user group."""
+    id: UUID
+    organization_id: UUID
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# =============================================================================
+# UserGroupMembership Schemas (#31)
+# =============================================================================
+
+class GroupMemberAdd(BaseModel):
+    """Schema for adding a member to a group."""
+    user_id: UUID
+    group_role: GroupRole = Field(default=GroupRole.MEMBER)
+
+
+class GroupMemberUpdate(BaseModel):
+    """Schema for updating a member's role in a group."""
+    group_role: GroupRole
+
+
+class GroupMemberRead(BaseModel):
+    """Schema for reading a group member."""
+    id: UUID
+    user_id: UUID
+    user_email: str = Field(description="User's email for display")
+    user_full_name: Optional[str] = Field(None, description="User's full name")
+    group_role: GroupRole
+    joined_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserGroupWithMembers(UserGroupRead):
+    """Schema for reading a user group with its members."""
+    members: List[GroupMemberRead] = Field(default_factory=list)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@ FastAPI application entry point.
 """
 from fastapi import FastAPI
 
-from app.api.v1.endpoint import admin, auth, exhibition, organization, zone, game_session, operations, user
+from app.api.v1.endpoint import admin, auth, exhibition, group, organization, zone, game_session, operations, user
 
 app = FastAPI(
     title="Structura Ludis API",
@@ -21,6 +21,11 @@ app.include_router(
     organization.router,
     prefix="/api/v1/organizations",
     tags=["Organizations"],
+)
+app.include_router(
+    group.router,
+    prefix="/api/v1/groups",
+    tags=["Groups"],
 )
 app.include_router(
     exhibition.router,

--- a/backend/tests/api/v1/test_group.py
+++ b/backend/tests/api/v1/test_group.py
@@ -1,0 +1,356 @@
+"""
+Tests for Group API endpoints (#31).
+"""
+import pytest
+from uuid import uuid4
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.organization.entity import UserGroup
+from app.domain.user.entity import UserGroupMembership
+from app.domain.shared.entity import UserGroupType, GroupRole
+
+
+class TestListGroups:
+    """Tests for GET /api/v1/groups/"""
+
+    async def test_list_empty(self, client: AsyncClient):
+        """Empty list returns 200 with empty array."""
+        response = await client.get("/api/v1/groups/")
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    async def test_list_with_filter(
+        self, auth_client: AsyncClient, test_organizer: dict
+    ):
+        """List filters by organization_id."""
+        # Create a group
+        group_payload = {
+            "name": "Test Partner Group",
+            "organization_id": test_organizer["organization_id"],
+            "type": "ASSOCIATION",
+        }
+        await auth_client.post("/api/v1/groups/", json=group_payload)
+
+        # List with filter
+        response = await auth_client.get(
+            f"/api/v1/groups/?organization_id={test_organizer['organization_id']}"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) >= 2  # Staff group + our new group
+        group_names = [g["name"] for g in data]
+        assert "Test Partner Group" in group_names
+
+
+class TestCreateGroup:
+    """Tests for POST /api/v1/groups/"""
+
+    async def test_create_success(
+        self, auth_client: AsyncClient, test_organizer: dict
+    ):
+        """Organizer can create a group."""
+        payload = {
+            "name": "New Partner Group",
+            "organization_id": test_organizer["organization_id"],
+            "type": "EXHIBITOR",
+            "is_public": True,
+        }
+
+        response = await auth_client.post("/api/v1/groups/", json=payload)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "New Partner Group"
+        assert data["type"] == "EXHIBITOR"
+        assert data["is_public"] is True
+
+    async def test_create_forbidden_for_user(
+        self, client: AsyncClient, test_user: dict, test_organization: dict
+    ):
+        """Regular user cannot create groups."""
+        payload = {
+            "name": "Forbidden Group",
+            "organization_id": test_organization["id"],
+            "type": "ASSOCIATION",
+        }
+
+        response = await client.post(
+            "/api/v1/groups/",
+            json=payload,
+            headers={"X-User-ID": test_user["id"]},
+        )
+
+        assert response.status_code == 403
+
+
+class TestGroupMembers:
+    """Tests for group member management endpoints."""
+
+    @pytest.fixture
+    async def test_group(
+        self, auth_client: AsyncClient, test_organizer: dict
+    ) -> dict:
+        """Create a test group."""
+        payload = {
+            "name": "Member Test Group",
+            "organization_id": test_organizer["organization_id"],
+            "type": "ASSOCIATION",
+        }
+        response = await auth_client.post("/api/v1/groups/", json=payload)
+        return response.json()
+
+    async def test_add_member(
+        self,
+        auth_client: AsyncClient,
+        test_group: dict,
+        test_user: dict,
+    ):
+        """Organizer can add a member to a group."""
+        response = await auth_client.post(
+            f"/api/v1/groups/{test_group['id']}/members",
+            json={"user_id": test_user["id"], "group_role": "MEMBER"},
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["user_id"] == test_user["id"]
+        assert data["group_role"] == "MEMBER"
+        assert "user_email" in data
+
+    async def test_add_member_already_exists(
+        self,
+        auth_client: AsyncClient,
+        test_group: dict,
+        test_user: dict,
+    ):
+        """Cannot add same member twice."""
+        # Add first time
+        await auth_client.post(
+            f"/api/v1/groups/{test_group['id']}/members",
+            json={"user_id": test_user["id"], "group_role": "MEMBER"},
+        )
+
+        # Try to add again
+        response = await auth_client.post(
+            f"/api/v1/groups/{test_group['id']}/members",
+            json={"user_id": test_user["id"], "group_role": "ADMIN"},
+        )
+
+        assert response.status_code == 409
+
+    async def test_list_members(
+        self,
+        auth_client: AsyncClient,
+        test_group: dict,
+        test_user: dict,
+    ):
+        """List group members."""
+        # Add a member
+        await auth_client.post(
+            f"/api/v1/groups/{test_group['id']}/members",
+            json={"user_id": test_user["id"], "group_role": "MEMBER"},
+        )
+
+        # List members
+        response = await auth_client.get(
+            f"/api/v1/groups/{test_group['id']}/members"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["user_id"] == test_user["id"]
+
+    async def test_update_member_role(
+        self,
+        auth_client: AsyncClient,
+        test_group: dict,
+        test_user: dict,
+    ):
+        """Update a member's role."""
+        # Add as member
+        await auth_client.post(
+            f"/api/v1/groups/{test_group['id']}/members",
+            json={"user_id": test_user["id"], "group_role": "MEMBER"},
+        )
+
+        # Promote to admin
+        response = await auth_client.patch(
+            f"/api/v1/groups/{test_group['id']}/members/{test_user['id']}",
+            json={"group_role": "ADMIN"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["group_role"] == "ADMIN"
+
+    async def test_remove_member(
+        self,
+        auth_client: AsyncClient,
+        test_group: dict,
+        test_user: dict,
+    ):
+        """Remove a member from group."""
+        # Add member
+        await auth_client.post(
+            f"/api/v1/groups/{test_group['id']}/members",
+            json={"user_id": test_user["id"], "group_role": "MEMBER"},
+        )
+
+        # Remove
+        response = await auth_client.delete(
+            f"/api/v1/groups/{test_group['id']}/members/{test_user['id']}"
+        )
+
+        assert response.status_code == 204
+
+        # Verify removed
+        members_resp = await auth_client.get(
+            f"/api/v1/groups/{test_group['id']}/members"
+        )
+        assert len(members_resp.json()) == 0
+
+    async def test_self_removal(
+        self,
+        auth_client: AsyncClient,
+        client: AsyncClient,
+        test_group: dict,
+        test_user: dict,
+    ):
+        """Member can remove themselves from group."""
+        # Add member
+        await auth_client.post(
+            f"/api/v1/groups/{test_group['id']}/members",
+            json={"user_id": test_user["id"], "group_role": "MEMBER"},
+        )
+
+        # Self-remove
+        response = await client.delete(
+            f"/api/v1/groups/{test_group['id']}/members/{test_user['id']}",
+            headers={"X-User-ID": test_user["id"]},
+        )
+
+        assert response.status_code == 204
+
+    async def test_cannot_remove_last_owner(
+        self,
+        auth_client: AsyncClient,
+        test_group: dict,
+        test_organizer: dict,
+    ):
+        """Cannot remove the last owner of a group."""
+        # Add organizer as owner
+        await auth_client.post(
+            f"/api/v1/groups/{test_group['id']}/members",
+            json={"user_id": test_organizer["user_id"], "group_role": "OWNER"},
+        )
+
+        # Try to remove
+        response = await auth_client.delete(
+            f"/api/v1/groups/{test_group['id']}/members/{test_organizer['user_id']}"
+        )
+
+        assert response.status_code == 400
+        assert "last owner" in response.json()["detail"]
+
+    async def test_cannot_demote_last_owner(
+        self,
+        auth_client: AsyncClient,
+        test_group: dict,
+        test_organizer: dict,
+    ):
+        """Cannot demote the last owner to member."""
+        # Add organizer as owner
+        await auth_client.post(
+            f"/api/v1/groups/{test_group['id']}/members",
+            json={"user_id": test_organizer["user_id"], "group_role": "OWNER"},
+        )
+
+        # Try to demote
+        response = await auth_client.patch(
+            f"/api/v1/groups/{test_group['id']}/members/{test_organizer['user_id']}",
+            json={"group_role": "MEMBER"},
+        )
+
+        assert response.status_code == 400
+        assert "last owner" in response.json()["detail"]
+
+
+class TestGroupPermissions:
+    """Tests for group-based permissions."""
+
+    @pytest.fixture
+    async def group_with_admin(
+        self,
+        auth_client: AsyncClient,
+        test_organizer: dict,
+        test_user: dict,
+    ) -> dict:
+        """Create a group with test_user as admin."""
+        # Create group
+        payload = {
+            "name": "Permission Test Group",
+            "organization_id": test_organizer["organization_id"],
+            "type": "ASSOCIATION",
+        }
+        group_resp = await auth_client.post("/api/v1/groups/", json=payload)
+        group = group_resp.json()
+
+        # Add test_user as admin
+        await auth_client.post(
+            f"/api/v1/groups/{group['id']}/members",
+            json={"user_id": test_user["id"], "group_role": "ADMIN"},
+        )
+
+        return group
+
+    async def test_group_admin_can_add_members(
+        self,
+        client: AsyncClient,
+        group_with_admin: dict,
+        test_user: dict,
+        second_test_user: dict,
+    ):
+        """Group admin can add new members."""
+        response = await client.post(
+            f"/api/v1/groups/{group_with_admin['id']}/members",
+            json={"user_id": second_test_user["id"], "group_role": "MEMBER"},
+            headers={"X-User-ID": test_user["id"]},
+        )
+
+        assert response.status_code == 201
+
+    async def test_regular_member_cannot_add_members(
+        self,
+        client: AsyncClient,
+        auth_client: AsyncClient,
+        test_organizer: dict,
+        test_user: dict,
+        second_test_user: dict,
+    ):
+        """Regular member cannot add new members."""
+        # Create group
+        payload = {
+            "name": "No Permission Group",
+            "organization_id": test_organizer["organization_id"],
+            "type": "ASSOCIATION",
+        }
+        group_resp = await auth_client.post("/api/v1/groups/", json=payload)
+        group = group_resp.json()
+
+        # Add test_user as regular member
+        await auth_client.post(
+            f"/api/v1/groups/{group['id']}/members",
+            json={"user_id": test_user["id"], "group_role": "MEMBER"},
+        )
+
+        # Try to add another member as regular member
+        response = await client.post(
+            f"/api/v1/groups/{group['id']}/members",
+            json={"user_id": second_test_user["id"], "group_role": "MEMBER"},
+            headers={"X-User-ID": test_user["id"]},
+        )
+
+        assert response.status_code == 403


### PR DESCRIPTION
## Summary

Implements JS.D2 - Partner team management with full CRUD for groups and members.

**New endpoints:**

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/groups` | List groups (optional org filter) |
| POST | `/groups` | Create group |
| GET | `/groups/{id}` | Get group details |
| PUT | `/groups/{id}` | Update group |
| DELETE | `/groups/{id}` | Delete group |
| GET | `/groups/{id}/members` | List members |
| POST | `/groups/{id}/members` | Add member |
| PATCH | `/groups/{id}/members/{user_id}` | Update role |
| DELETE | `/groups/{id}/members/{user_id}` | Remove member |

**Role hierarchy:** OWNER > ADMIN > MEMBER
- Owners can manage all members and roles
- Admins can add/remove regular members
- Members can only view and self-remove

**Protections:**
- Cannot remove/demote the last owner
- Duplicate membership prevented
- Public/private group visibility

## Test plan

- [x] List groups with organization filter
- [x] Create group (organizer only)
- [x] Forbidden for regular users
- [x] Add member to group
- [x] Prevent duplicate membership
- [x] List group members
- [x] Update member role
- [x] Remove member
- [x] Self-removal works
- [x] Cannot remove last owner
- [x] Cannot demote last owner
- [x] Group admin can add members
- [x] Regular member cannot add members
- [x] All 198 tests passing

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)