### PR TITLE
Add privacy policy consent requirement at registration (#47)

### DIFF
--- a/backend/alembic/versions/7ef43afa9420_add_privacy_accepted_at_to_users.py
+++ b/backend/alembic/versions/7ef43afa9420_add_privacy_accepted_at_to_users.py
@@ -1,0 +1,30 @@
+"""Add privacy_accepted_at to users
+
+Revision ID: 7ef43afa9420
+Revises: acb21cf6f99d
+Create Date: 2026-01-30 11:55:26.864835
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '7ef43afa9420'
+down_revision: Union[str, Sequence[str], None] = 'acb21cf6f99d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'users',
+        sa.Column('privacy_accepted_at', sa.DateTime(timezone=True), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('users', 'privacy_accepted_at')

--- a/backend/app/domain/auth/schemas.py
+++ b/backend/app/domain/auth/schemas.py
@@ -17,6 +17,10 @@ class RegisterRequest(BaseModel):
     email: EmailStr
     password: str = Field(..., min_length=8)
     full_name: str = Field(None, max_length=255)
+    accept_privacy_policy: bool = Field(
+        ...,
+        description="User must accept the privacy policy to register"
+    )
 
 
 class Token(BaseModel):

--- a/backend/app/domain/user/entity.py
+++ b/backend/app/domain/user/entity.py
@@ -40,6 +40,11 @@ class User(Base, TimestampMixin):
     birth_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
 
+    # GDPR: Privacy policy consent (Issue #47)
+    privacy_accepted_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     def get_age(self) -> Optional[int]:
         """Calculate age from birth_date."""
         if not self.birth_date:

--- a/backend/app/domain/user/schemas.py
+++ b/backend/app/domain/user/schemas.py
@@ -31,6 +31,7 @@ class UserRead(UserBase):
     global_role: str  # String from DB, matches GlobalRole values
     is_active: bool
     last_login: Optional[datetime] = None
+    privacy_accepted_at: Optional[datetime] = None  # GDPR consent timestamp
     created_at: datetime
     updated_at: Optional[datetime] = None
 

--- a/backend/doc/TODO.md
+++ b/backend/doc/TODO.md
@@ -7,10 +7,10 @@
 
 | Status | Count | Coverage |
 |--------|-------|----------|
-| Implemented | 27 features | 73% |
+| Implemented | 28 features | 76% |
 | Partial | 1 feature | 3% |
-| Not implemented | 10 features | 24% |
-| **Total PRD coverage** | | **~76%** |
+| Not implemented | 9 features | 21% |
+| **Total PRD coverage** | | **~79%** |
 
 ---
 
@@ -27,7 +27,7 @@
 
 | Feature | PRD Ref | Issue | Complexity | Effort |
 |---------|---------|-------|------------|--------|
-| Privacy Policy Consent | JS.E1 | #47 | Low | 1-2 days |
+| ~~Privacy Policy Consent~~ | JS.E1 | #47 | ✅ Done | - |
 | Data Access (Right of Access) | JS.E2 | #48 | Medium | 2-3 days |
 | Account Deletion (Right to Erasure) | JS.E3 | #49 | High | 3-5 days |
 | Data Portability | JS.E4 | #50 | Low | 1 day |
@@ -188,15 +188,14 @@ Added to Exhibition entity:
 
 ---
 
-### Privacy Policy Consent (JS.E1) - #47
+### ~~Privacy Policy Consent (JS.E1) - #47~~ ✅ DONE
 
-**Current state:** Not implemented
-
-**Required:**
-- [ ] Add `privacy_accepted_at: datetime` field to User entity
-- [ ] Require consent checkbox during registration
-- [ ] `POST /auth/register` validates consent
-- [ ] Privacy policy page (frontend)
+GDPR consent requirement at registration:
+- `privacy_accepted_at` field added to User entity
+- `accept_privacy_policy: bool` required in RegisterRequest
+- Registration blocked if consent not given (400 error)
+- Consent timestamp stored for audit purposes
+- Frontend: Privacy policy page to be implemented separately
 
 ---
 
@@ -344,7 +343,7 @@ Added to Exhibition entity:
 11. #41 - Multi-language email templates
 
 ### Phase 4: GDPR Compliance (3-4 weeks)
-12. #47 - Privacy Policy Consent (JS.E1)
+12. ~~#47 - Privacy Policy Consent (JS.E1)~~ ✅
 13. #51 - Consent Management (JS.E5)
 14. #48 - Data Access / Export (JS.E2)
 15. #50 - Data Portability (JS.E4)

--- a/backend/doc/database-schema.mmd
+++ b/backend/doc/database-schema.mmd
@@ -37,6 +37,7 @@ erDiagram
         string timezone
         string locale
         boolean is_active
+        datetime privacy_accepted_at "Issue 47 - GDPR consent"
         datetime last_login
         datetime created_at
         datetime updated_at

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -34,8 +34,9 @@ async def db_session(test_engine) -> AsyncGenerator[AsyncSession, None]:
 
     Each test runs in isolation with a clean state.
     """
-    # Create tables
+    # Drop and recreate tables to ensure schema is up to date
     async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)
 
     # Create session


### PR DESCRIPTION
Closes #47

## Summary

GDPR compliance: Users must explicitly accept the privacy policy during registration.

- Add `privacy_accepted_at` timestamp field to User entity
- Add `accept_privacy_policy: bool` required field to RegisterRequest schema
- Block registration with HTTP 400 if consent not given
- Store consent timestamp for audit purposes
- Return `privacy_accepted_at` in UserRead response

## Changes

- `app/domain/user/entity.py` - Add `privacy_accepted_at` field
- `app/domain/auth/schemas.py` - Add `accept_privacy_policy` to RegisterRequest
- `app/services/auth.py` - Validate consent, set timestamp, add exception
- `app/api/v1/endpoint/auth.py` - Handle PrivacyPolicyNotAcceptedError
- `app/domain/user/schemas.py` - Add `privacy_accepted_at` to UserRead
- Migration for new column

## Test plan

- [x] Run auth tests - 14 tests passing
- [x] Run full test suite - 253 tests passing
- [x] Test registration without `accept_privacy_policy` field → 422
- [x] Test registration with `accept_privacy_policy: false` → 400
- [x] Test registration with `accept_privacy_policy: true` → 201 + timestamp set

## Frontend TODO

- [ ] Add privacy policy page
- [ ] Add consent checkbox to registration form

🤖 Generated with [Claude Code](https://claude.com/claude-code)