### PR TITLE
Add time slots management tab (#7)

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -313,7 +313,22 @@
     "primaryLanguage": "Primary language",
     "saving": "Saving...",
     "settingsSaved": "Settings saved successfully",
-    "saveError": "Failed to save settings"
+    "saveError": "Failed to save settings",
+    "addSlot": "Add time slot",
+    "editSlot": "Edit time slot",
+    "noSlots": "No time slots configured",
+    "slotName": "Slot name",
+    "slotNamePlaceholder": "e.g. Saturday Morning",
+    "startTime": "Start time",
+    "endTime": "End time",
+    "maxDuration": "Max session duration (minutes)",
+    "maxDurationHelper": "Maximum duration for sessions in this slot",
+    "bufferTime": "Buffer time (minutes)",
+    "bufferTimeHelper": "Setup time between sessions",
+    "maxDurationValue": "Max: {duration}",
+    "bufferTimeValue": "Buffer: {duration}",
+    "confirmDeleteSlotTitle": "Delete time slot?",
+    "confirmDeleteSlotMessage": "Are you sure you want to delete \"{name}\"? This action cannot be undone."
   },
   "SessionForm": {
     "pageTitle": "Propose a session",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -313,7 +313,22 @@
     "primaryLanguage": "Langue principale",
     "saving": "Enregistrement...",
     "settingsSaved": "Paramètres enregistrés avec succès",
-    "saveError": "Échec de l'enregistrement des paramètres"
+    "saveError": "Échec de l'enregistrement des paramètres",
+    "addSlot": "Ajouter un créneau",
+    "editSlot": "Modifier le créneau",
+    "noSlots": "Aucun créneau configuré",
+    "slotName": "Nom du créneau",
+    "slotNamePlaceholder": "ex. Samedi Matin",
+    "startTime": "Heure de début",
+    "endTime": "Heure de fin",
+    "maxDuration": "Durée max des sessions (minutes)",
+    "maxDurationHelper": "Durée maximale des sessions dans ce créneau",
+    "bufferTime": "Temps de battement (minutes)",
+    "bufferTimeHelper": "Temps d'installation entre les sessions",
+    "maxDurationValue": "Max : {duration}",
+    "bufferTimeValue": "Battement : {duration}",
+    "confirmDeleteSlotTitle": "Supprimer le créneau ?",
+    "confirmDeleteSlotMessage": "Êtes-vous sûr de vouloir supprimer \"{name}\" ? Cette action est irréversible."
   },
   "SessionForm": {
     "pageTitle": "Proposer une session",

--- a/frontend/src/app/[locale]/exhibitions/[id]/manage/page.tsx
+++ b/frontend/src/app/[locale]/exhibitions/[id]/manage/page.tsx
@@ -7,7 +7,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useRouter } from '@/i18n/routing';
 import { exhibitionsApi, Exhibition } from '@/lib/api';
 import { Card } from '@/components/ui';
-import { ExhibitionSettingsForm } from '@/components/admin';
+import { ExhibitionSettingsForm, TimeSlotList } from '@/components/admin';
 
 type TabId = 'settings' | 'slots' | 'zones';
 
@@ -153,9 +153,7 @@ export default function ManageExhibitionPage() {
             />
           )}
           {activeTab === 'slots' && (
-            <div className="text-center py-8" style={{ color: 'var(--color-text-muted)' }}>
-              {t('comingSoon')}
-            </div>
+            <TimeSlotList exhibitionId={exhibition.id} />
           )}
           {activeTab === 'zones' && (
             <div className="text-center py-8" style={{ color: 'var(--color-text-muted)' }}>

--- a/frontend/src/components/admin/TimeSlotForm.tsx
+++ b/frontend/src/components/admin/TimeSlotForm.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { useTranslations } from 'next-intl';
+import { TimeSlot, TimeSlotCreate } from '@/lib/api';
+import { Button, Input } from '@/components/ui';
+
+const timeSlotSchema = z.object({
+  name: z.string().min(1).max(100),
+  start_time: z.string().min(1),
+  end_time: z.string().min(1),
+  max_duration_minutes: z.coerce.number().min(30).max(720),
+  buffer_time_minutes: z.coerce.number().min(0).max(60),
+});
+
+type TimeSlotFormData = z.infer<typeof timeSlotSchema>;
+
+interface TimeSlotFormProps {
+  slot?: TimeSlot | null;
+  onSubmit: (data: TimeSlotCreate) => Promise<void>;
+  onCancel: () => void;
+  isSubmitting: boolean;
+}
+
+function formatDateTimeLocal(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toISOString().slice(0, 16);
+}
+
+export function TimeSlotForm({
+  slot,
+  onSubmit,
+  onCancel,
+  isSubmitting,
+}: TimeSlotFormProps) {
+  const t = useTranslations('Admin');
+  const tCommon = useTranslations('Common');
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<TimeSlotFormData>({
+    resolver: zodResolver(timeSlotSchema),
+    defaultValues: {
+      name: '',
+      start_time: '',
+      end_time: '',
+      max_duration_minutes: 240,
+      buffer_time_minutes: 15,
+    },
+  });
+
+  useEffect(() => {
+    if (slot) {
+      reset({
+        name: slot.name,
+        start_time: formatDateTimeLocal(slot.start_time),
+        end_time: formatDateTimeLocal(slot.end_time),
+        max_duration_minutes: slot.max_duration_minutes,
+        buffer_time_minutes: slot.buffer_time_minutes,
+      });
+    } else {
+      reset({
+        name: '',
+        start_time: '',
+        end_time: '',
+        max_duration_minutes: 240,
+        buffer_time_minutes: 15,
+      });
+    }
+  }, [slot, reset]);
+
+  const handleFormSubmit = async (data: TimeSlotFormData) => {
+    const payload = {
+      name: data.name,
+      start_time: new Date(data.start_time).toISOString(),
+      end_time: new Date(data.end_time).toISOString(),
+      max_duration_minutes: data.max_duration_minutes,
+      buffer_time_minutes: data.buffer_time_minutes,
+    };
+    await onSubmit(payload);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(handleFormSubmit)} className="space-y-4">
+      <Input
+        {...register('name')}
+        label={t('slotName')}
+        placeholder={t('slotNamePlaceholder')}
+        error={errors.name?.message}
+      />
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Input
+          {...register('start_time')}
+          type="datetime-local"
+          label={t('startTime')}
+          error={errors.start_time?.message}
+        />
+
+        <Input
+          {...register('end_time')}
+          type="datetime-local"
+          label={t('endTime')}
+          error={errors.end_time?.message}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Input
+          {...register('max_duration_minutes')}
+          type="number"
+          min={30}
+          max={720}
+          label={t('maxDuration')}
+          helperText={t('maxDurationHelper')}
+          error={errors.max_duration_minutes?.message}
+        />
+
+        <Input
+          {...register('buffer_time_minutes')}
+          type="number"
+          min={0}
+          max={60}
+          label={t('bufferTime')}
+          helperText={t('bufferTimeHelper')}
+          error={errors.buffer_time_minutes?.message}
+        />
+      </div>
+
+      <div className="flex justify-end gap-3 pt-4">
+        <Button type="button" variant="secondary" onClick={onCancel}>
+          {tCommon('cancel')}
+        </Button>
+        <Button type="submit" variant="primary" disabled={isSubmitting}>
+          {isSubmitting ? t('saving') : tCommon('save')}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/admin/TimeSlotList.tsx
+++ b/frontend/src/components/admin/TimeSlotList.tsx
@@ -1,0 +1,304 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useTranslations } from 'next-intl';
+import { exhibitionsApi, TimeSlot, TimeSlotCreate } from '@/lib/api';
+import { Button, Card, ConfirmDialog } from '@/components/ui';
+import { TimeSlotForm } from './TimeSlotForm';
+
+interface TimeSlotListProps {
+  exhibitionId: string;
+}
+
+function formatDateTime(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleString('fr-FR', {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatDuration(minutes: number): string {
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  if (hours === 0) return `${mins}min`;
+  if (mins === 0) return `${hours}h`;
+  return `${hours}h${mins}`;
+}
+
+export function TimeSlotList({ exhibitionId }: TimeSlotListProps) {
+  const t = useTranslations('Admin');
+  const tCommon = useTranslations('Common');
+
+  const [slots, setSlots] = useState<TimeSlot[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingSlot, setEditingSlot] = useState<TimeSlot | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const [deleteSlot, setDeleteSlot] = useState<TimeSlot | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // Load slots
+  useEffect(() => {
+    async function loadSlots() {
+      setIsLoading(true);
+      setError(null);
+
+      const response = await exhibitionsApi.getTimeSlots(exhibitionId);
+
+      if (response.error) {
+        setError(response.error.message);
+      } else if (response.data) {
+        setSlots(response.data);
+      }
+
+      setIsLoading(false);
+    }
+
+    loadSlots();
+  }, [exhibitionId]);
+
+  const handleCreate = async (data: TimeSlotCreate) => {
+    setIsSubmitting(true);
+    setError(null);
+
+    const response = await exhibitionsApi.createTimeSlot(exhibitionId, data);
+
+    if (response.error) {
+      setError(response.error.message);
+    } else if (response.data) {
+      setSlots((prev) =>
+        [...prev, response.data!].sort(
+          (a, b) =>
+            new Date(a.start_time).getTime() - new Date(b.start_time).getTime()
+        )
+      );
+      setIsFormOpen(false);
+    }
+
+    setIsSubmitting(false);
+  };
+
+  const handleUpdate = async (data: TimeSlotCreate) => {
+    if (!editingSlot) return;
+
+    setIsSubmitting(true);
+    setError(null);
+
+    const response = await exhibitionsApi.updateTimeSlot(
+      exhibitionId,
+      editingSlot.id,
+      data
+    );
+
+    if (response.error) {
+      setError(response.error.message);
+    } else if (response.data) {
+      setSlots((prev) =>
+        prev
+          .map((s) => (s.id === editingSlot.id ? response.data! : s))
+          .sort(
+            (a, b) =>
+              new Date(a.start_time).getTime() -
+              new Date(b.start_time).getTime()
+          )
+      );
+      setEditingSlot(null);
+    }
+
+    setIsSubmitting(false);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteSlot) return;
+
+    setIsDeleting(true);
+    setError(null);
+
+    const response = await exhibitionsApi.deleteTimeSlot(
+      exhibitionId,
+      deleteSlot.id
+    );
+
+    if (response.error) {
+      setError(response.error.message);
+    } else {
+      setSlots((prev) => prev.filter((s) => s.id !== deleteSlot.id));
+      setDeleteSlot(null);
+    }
+
+    setIsDeleting(false);
+  };
+
+  const openCreateForm = () => {
+    setEditingSlot(null);
+    setIsFormOpen(true);
+  };
+
+  const openEditForm = (slot: TimeSlot) => {
+    setIsFormOpen(false);
+    setEditingSlot(slot);
+  };
+
+  const closeForm = () => {
+    setIsFormOpen(false);
+    setEditingSlot(null);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="animate-pulse space-y-3">
+        {[1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="h-16 bg-slate-200 dark:bg-slate-700 rounded"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div className="p-3 bg-red-500/10 border border-red-500/30 rounded-lg text-red-600 dark:text-red-400 text-sm">
+          {error}
+        </div>
+      )}
+
+      {/* Add button */}
+      {!isFormOpen && !editingSlot && (
+        <div className="flex justify-end">
+          <Button variant="primary" onClick={openCreateForm}>
+            {t('addSlot')}
+          </Button>
+        </div>
+      )}
+
+      {/* Create form */}
+      {isFormOpen && (
+        <Card>
+          <Card.Content>
+            <h4
+              className="text-lg font-medium mb-4"
+              style={{ color: 'var(--color-text-primary)' }}
+            >
+              {t('addSlot')}
+            </h4>
+            <TimeSlotForm
+              onSubmit={handleCreate}
+              onCancel={closeForm}
+              isSubmitting={isSubmitting}
+            />
+          </Card.Content>
+        </Card>
+      )}
+
+      {/* Slot list */}
+      {slots.length === 0 && !isFormOpen ? (
+        <div
+          className="text-center py-8"
+          style={{ color: 'var(--color-text-muted)' }}
+        >
+          {t('noSlots')}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {slots.map((slot) => (
+            <div key={slot.id}>
+              {editingSlot?.id === slot.id ? (
+                <Card>
+                  <Card.Content>
+                    <h4
+                      className="text-lg font-medium mb-4"
+                      style={{ color: 'var(--color-text-primary)' }}
+                    >
+                      {t('editSlot')}
+                    </h4>
+                    <TimeSlotForm
+                      slot={slot}
+                      onSubmit={handleUpdate}
+                      onCancel={closeForm}
+                      isSubmitting={isSubmitting}
+                    />
+                  </Card.Content>
+                </Card>
+              ) : (
+                <div
+                  className="flex items-center justify-between p-4 rounded-lg border"
+                  style={{
+                    borderColor: 'var(--color-border)',
+                    backgroundColor: 'var(--color-bg-secondary)',
+                  }}
+                >
+                  <div className="flex-1">
+                    <div
+                      className="font-medium"
+                      style={{ color: 'var(--color-text-primary)' }}
+                    >
+                      {slot.name}
+                    </div>
+                    <div
+                      className="text-sm"
+                      style={{ color: 'var(--color-text-secondary)' }}
+                    >
+                      {formatDateTime(slot.start_time)} -{' '}
+                      {formatDateTime(slot.end_time)}
+                    </div>
+                    <div
+                      className="text-xs mt-1"
+                      style={{ color: 'var(--color-text-muted)' }}
+                    >
+                      {t('maxDurationValue', {
+                        duration: formatDuration(slot.max_duration_minutes),
+                      })}{' '}
+                      &bull;{' '}
+                      {t('bufferTimeValue', {
+                        duration: formatDuration(slot.buffer_time_minutes),
+                      })}
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => openEditForm(slot)}
+                    >
+                      {tCommon('edit')}
+                    </Button>
+                    <Button
+                      variant="danger"
+                      size="sm"
+                      onClick={() => setDeleteSlot(slot)}
+                    >
+                      {tCommon('delete')}
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Delete confirmation */}
+      <ConfirmDialog
+        isOpen={!!deleteSlot}
+        title={t('confirmDeleteSlotTitle')}
+        message={t('confirmDeleteSlotMessage', { name: deleteSlot?.name })}
+        confirmLabel={tCommon('delete')}
+        cancelLabel={tCommon('cancel')}
+        variant="danger"
+        isLoading={isDeleting}
+        onConfirm={handleDelete}
+        onClose={() => setDeleteSlot(null)}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/admin/index.ts
+++ b/frontend/src/components/admin/index.ts
@@ -1,1 +1,3 @@
 export { ExhibitionSettingsForm } from './ExhibitionSettingsForm';
+export { TimeSlotList } from './TimeSlotList';
+export { TimeSlotForm } from './TimeSlotForm';


### PR DESCRIPTION
## Summary
- Create `TimeSlotForm` component for create/edit time slots
- Create `TimeSlotList` component with full CRUD operations
- Integrate `TimeSlotList` in the manage page (replaces "Coming soon")
- Add Admin translations for time slot management (en/fr)

This is PR 3 of 4 for issue #7 (Admin: Event Configuration).

## Test plan
- [ ] Navigate to `/exhibitions/{id}/manage` as organizer
- [ ] Click on "Time Slots" tab
- [ ] Add a new time slot
- [ ] Edit an existing time slot
- [ ] Delete a time slot (with confirmation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)