### PR TITLE
Add self-hosting deployment structure

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,0 +1,67 @@
+# =============================================================================
+# Structura Ludis API - Production Dockerfile
+# =============================================================================
+# Multi-stage build for optimized production image
+
+# Stage 1: Build dependencies
+FROM python:3.12-slim AS builder
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libpq-dev \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Poetry
+RUN curl -sSL https://install.python-poetry.org | python3 -
+ENV PATH="/root/.local/bin:$PATH"
+RUN poetry self add poetry-plugin-export
+
+# Copy dependency files
+COPY pyproject.toml poetry.lock* ./
+
+# Export requirements (without dev dependencies)
+RUN poetry export -f requirements.txt --output requirements.txt --without-hashes --without dev
+
+# Stage 2: Production image
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install runtime dependencies only
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpq5 \
+    curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --shell /bin/bash appuser
+
+# Copy requirements and install
+COPY --from=builder /app/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY --chown=appuser:appuser . .
+
+# Switch to non-root user
+USER appuser
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+    CMD curl -f http://localhost:8000/health || exit 1
+
+# Expose port
+EXPOSE 8000
+
+# Run with gunicorn for production
+CMD ["gunicorn", "app.main:app", \
+    "--bind", "0.0.0.0:8000", \
+    "--workers", "4", \
+    "--worker-class", "uvicorn.workers.UvicornWorker", \
+    "--access-logfile", "-", \
+    "--error-logfile", "-"]

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -550,6 +550,27 @@ docs = ["Sphinx", "furo"]
 test = ["objgraph", "psutil", "setuptools"]
 
 [[package]]
+name = "gunicorn"
+version = "21.2.0"
+description = "WSGI HTTP Server for UNIX"
+optional = false
+python-versions = ">=3.5"
+groups = ["main"]
+files = [
+    {file = "gunicorn-21.2.0-py3-none-any.whl", hash = "sha256:3213aa5e8c24949e792bcacfc176fef362e7aac80b76c56f6b5122bf350722f0"},
+    {file = "gunicorn-21.2.0.tar.gz", hash = "sha256:88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033"},
+]
+
+[package.dependencies]
+packaging = "*"
+
+[package.extras]
+eventlet = ["eventlet (>=0.24.1)"]
+gevent = ["gevent (>=1.4.0)"]
+setproctitle = ["setproctitle"]
+tornado = ["tornado (>=0.2)"]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -831,7 +852,7 @@ version = "26.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"},
     {file = "packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4"},
@@ -1793,4 +1814,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "0f378937031f7af48d3219c248f4d1ed980f311ef8bd2da05da32ba408a0faa1"
+content-hash = "3cda200b8156ae1a530cf8bf74bc0e42ed394102fa3d0b30dcdf0faee9ba5038"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     "python-jose[cryptography] (>=3.3.0,<4.0.0)",
     "passlib[bcrypt] (>=1.7.4,<2.0.0)",
     "bcrypt (>=4.0.0,<5.0.0)",
-    "jinja2 (>=3.1.6,<4.0.0)"
+    "jinja2 (>=3.1.6,<4.0.0)",
+    "gunicorn (>=21.0.0,<22.0.0)"
 ]
 
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,69 @@
+# =============================================================================
+# Structura Ludis - Production Environment Configuration
+# =============================================================================
+# Copy this file to .env and configure your values
+# NEVER commit .env files to version control!
+
+# -----------------------------------------------------------------------------
+# Database Configuration
+# -----------------------------------------------------------------------------
+POSTGRES_USER=sl_admin
+POSTGRES_PASSWORD=CHANGE_ME_use_a_strong_password
+POSTGRES_DB=structura_ludis
+
+# Full database URL (constructed from above, or set directly)
+DATABASE_URL=postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@sl-db:5432/${POSTGRES_DB}
+
+# -----------------------------------------------------------------------------
+# Application Settings
+# -----------------------------------------------------------------------------
+# Secret key for JWT tokens - MUST be changed in production!
+# Generate with: openssl rand -hex 32
+SECRET_KEY=CHANGE_ME_generate_with_openssl_rand_hex_32
+
+# Environment: development, staging, production
+ENVIRONMENT=production
+
+# Debug mode (set to false in production)
+DEBUG=false
+
+# Allowed hosts (comma-separated)
+ALLOWED_HOSTS=localhost,your-domain.com
+
+# CORS origins (comma-separated, use your frontend URL)
+CORS_ORIGINS=https://your-domain.com
+
+# -----------------------------------------------------------------------------
+# Email Configuration (SMTP)
+# -----------------------------------------------------------------------------
+# For production, use a real SMTP server (SendGrid, Mailgun, SES, etc.)
+SMTP_HOST=smtp.your-provider.com
+SMTP_PORT=587
+SMTP_USER=your-smtp-user
+SMTP_PASSWORD=your-smtp-password
+SMTP_FROM=noreply@your-domain.com
+SMTP_TLS=true
+
+# -----------------------------------------------------------------------------
+# Frontend Configuration
+# -----------------------------------------------------------------------------
+# Public URL of the frontend (used in emails, etc.)
+FRONTEND_URL=https://your-domain.com
+
+# API URL as seen by the frontend container
+API_URL=http://sl-api:8000
+
+# -----------------------------------------------------------------------------
+# Optional: External Services
+# -----------------------------------------------------------------------------
+# Sentry DSN for error tracking (optional)
+# SENTRY_DSN=https://xxx@sentry.io/xxx
+
+# -----------------------------------------------------------------------------
+# Traefik Configuration (if using Traefik reverse proxy)
+# -----------------------------------------------------------------------------
+# Your domain name
+DOMAIN=your-domain.com
+
+# Let's Encrypt email for SSL certificates
+LETSENCRYPT_EMAIL=admin@your-domain.com

--- a/deploy/README-selfhost.md
+++ b/deploy/README-selfhost.md
@@ -1,0 +1,206 @@
+# Self-Hosting Structura Ludis
+
+This guide explains how to self-host Structura Ludis using Docker, including setup on Synology NAS with Container Manager.
+
+## Requirements
+
+- Docker Engine 20.10+ and Docker Compose v2
+- 1GB RAM minimum (2GB recommended)
+- 10GB disk space
+- A domain name (for HTTPS)
+
+## Quick Start
+
+### 1. Download the deployment files
+
+```bash
+# Clone the repository (or download just the deploy folder)
+git clone https://github.com/lolautruche/StructuraLudis.git
+cd StructuraLudis/deploy
+```
+
+### 2. Configure environment
+
+```bash
+# Copy the example environment file
+cp .env.example .env
+
+# Edit with your settings
+nano .env
+```
+
+**Critical settings to change:**
+- `POSTGRES_PASSWORD` - Use a strong password
+- `SECRET_KEY` - Generate with `openssl rand -hex 32`
+- `DOMAIN` - Your domain name
+- `LETSENCRYPT_EMAIL` - For SSL certificates
+- `SMTP_*` - Your email provider settings
+
+### 3. Start the services
+
+```bash
+# Without reverse proxy (for testing)
+docker compose -f docker-compose.prod.yml up -d
+
+# With Traefik reverse proxy (recommended for production)
+docker compose -f docker-compose.prod.yml -f traefik/docker-compose.traefik.yml up -d
+```
+
+### 4. Initialize the database
+
+```bash
+# Run database migrations
+docker compose -f docker-compose.prod.yml exec sl-api alembic upgrade head
+
+# (Optional) Seed with demo data
+docker compose -f docker-compose.prod.yml exec sl-api python -m scripts.seed_db
+```
+
+### 5. Access the application
+
+- Without Traefik: http://localhost:3000
+- With Traefik: https://your-domain.com
+
+---
+
+## Synology NAS (Container Manager)
+
+### Method 1: Using Container Manager Projects
+
+1. **Open Container Manager** > **Project** > **Create**
+
+2. **Upload docker-compose.prod.yml** as the project file
+
+3. **Configure environment variables** in the Container Manager UI:
+   - Click on the project settings
+   - Add all required variables from `.env.example`
+
+4. **Start the project**
+
+5. **Run migrations** via SSH or Task Scheduler:
+   ```bash
+   docker exec sl_api alembic upgrade head
+   ```
+
+### Method 2: Manual Container Setup
+
+If you prefer manual control:
+
+1. **Create a network**: `sl-network` (bridge mode)
+
+2. **Create PostgreSQL container**:
+   - Image: `postgres:16-alpine`
+   - Network: `sl-network`
+   - Volume: Map a folder for `/var/lib/postgresql/data`
+   - Environment: Set `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`
+
+3. **Create API container**:
+   - Image: `ghcr.io/lolautruche/structuraludis-api:latest`
+   - Network: `sl-network`
+   - Environment: Set all required variables
+
+4. **Create Frontend container**:
+   - Image: `ghcr.io/lolautruche/structuraludis-frontend:latest`
+   - Network: `sl-network`
+   - Port: Map to your desired port
+
+### Reverse Proxy on Synology
+
+If using Synology's built-in reverse proxy:
+
+1. **Control Panel** > **Login Portal** > **Advanced** > **Reverse Proxy**
+
+2. **Create rule for frontend**:
+   - Source: `https://your-domain.com:443`
+   - Destination: `http://localhost:3000`
+
+3. **Create rule for API**:
+   - Source: `https://your-domain.com:443/api`
+   - Destination: `http://localhost:8000/api`
+
+---
+
+## Backup & Restore
+
+### Backup
+
+```bash
+# Backup database
+docker exec sl_postgres pg_dump -U sl_admin structura_ludis > backup_$(date +%Y%m%d).sql
+
+# Backup volumes (if using named volumes)
+docker run --rm -v sl_postgres_data:/data -v $(pwd):/backup alpine tar czf /backup/postgres_data.tar.gz /data
+```
+
+### Restore
+
+```bash
+# Restore database
+cat backup_20260201.sql | docker exec -i sl_postgres psql -U sl_admin structura_ludis
+
+# Restore volumes
+docker run --rm -v sl_postgres_data:/data -v $(pwd):/backup alpine tar xzf /backup/postgres_data.tar.gz -C /
+```
+
+---
+
+## Updating
+
+```bash
+# Pull latest images
+docker compose -f docker-compose.prod.yml pull
+
+# Restart with new images
+docker compose -f docker-compose.prod.yml up -d
+
+# Run any new migrations
+docker compose -f docker-compose.prod.yml exec sl-api alembic upgrade head
+```
+
+---
+
+## Troubleshooting
+
+### Check logs
+
+```bash
+# All services
+docker compose -f docker-compose.prod.yml logs -f
+
+# Specific service
+docker compose -f docker-compose.prod.yml logs -f sl-api
+```
+
+### Database connection issues
+
+```bash
+# Check if database is ready
+docker exec sl_postgres pg_isready -U sl_admin
+
+# Check database logs
+docker logs sl_postgres
+```
+
+### Reset everything
+
+```bash
+# Stop and remove all containers and volumes (WARNING: deletes all data!)
+docker compose -f docker-compose.prod.yml down -v
+```
+
+---
+
+## Security Recommendations
+
+1. **Change default passwords** - Never use example passwords in production
+2. **Use HTTPS** - Always use a reverse proxy with SSL in production
+3. **Firewall** - Only expose ports 80/443, keep database internal
+4. **Updates** - Regularly update Docker images for security patches
+5. **Backups** - Set up automated backups of the database
+
+---
+
+## Support
+
+- Documentation: https://github.com/lolautruche/StructuraLudis
+- Issues: https://github.com/lolautruche/StructuraLudis/issues

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,0 +1,132 @@
+# =============================================================================
+# Structura Ludis - Production Docker Compose
+# =============================================================================
+# Usage:
+#   1. Copy .env.example to .env and configure your values
+#   2. Run: docker compose -f docker-compose.prod.yml up -d
+#   3. Run migrations: docker compose -f docker-compose.prod.yml exec sl-api alembic upgrade head
+#   4. (Optional) Seed database: docker compose -f docker-compose.prod.yml exec sl-api python -m scripts.seed_db
+#
+# For Synology NAS / Container Manager:
+#   - Import this file via Container Manager > Project
+#   - Configure environment variables in the UI
+#   - Use with a reverse proxy for HTTPS (see traefik/ folder for example)
+
+services:
+  # ---------------------------------------------------------------------------
+  # PostgreSQL Database
+  # ---------------------------------------------------------------------------
+  sl-db:
+    image: postgres:16-alpine
+    container_name: sl_postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-sl_admin}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Database password is required}
+      POSTGRES_DB: ${POSTGRES_DB:-structura_ludis}
+    volumes:
+      - sl_postgres_data:/var/lib/postgresql/data
+    networks:
+      - sl-internal
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-sl_admin} -d ${POSTGRES_DB:-structura_ludis}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    # Security: don't expose database port externally in production
+    # ports:
+    #   - "5432:5432"
+
+  # ---------------------------------------------------------------------------
+  # Backend API (FastAPI)
+  # ---------------------------------------------------------------------------
+  sl-api:
+    image: ghcr.io/lolautruche/structuraludis-api:latest
+    # Or build locally:
+    # build:
+    #   context: ../backend
+    #   dockerfile: Dockerfile.prod
+    container_name: sl_api
+    restart: unless-stopped
+    depends_on:
+      sl-db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-sl_admin}:${POSTGRES_PASSWORD}@sl-db:5432/${POSTGRES_DB:-structura_ludis}
+      SECRET_KEY: ${SECRET_KEY:?Secret key is required}
+      ENVIRONMENT: ${ENVIRONMENT:-production}
+      DEBUG: ${DEBUG:-false}
+      CORS_ORIGINS: ${CORS_ORIGINS:-}
+      SMTP_HOST: ${SMTP_HOST:-}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USER: ${SMTP_USER:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      SMTP_FROM: ${SMTP_FROM:-}
+      SMTP_TLS: ${SMTP_TLS:-true}
+      FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3000}
+    networks:
+      - sl-internal
+      - sl-external
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    # Expose for reverse proxy
+    expose:
+      - "8000"
+    # Or direct access (not recommended for production):
+    # ports:
+    #   - "8000:8000"
+
+  # ---------------------------------------------------------------------------
+  # Frontend (Next.js)
+  # ---------------------------------------------------------------------------
+  sl-frontend:
+    image: ghcr.io/lolautruche/structuraludis-frontend:latest
+    # Or build locally:
+    # build:
+    #   context: ../frontend
+    #   dockerfile: Dockerfile.prod
+    container_name: sl_frontend
+    restart: unless-stopped
+    depends_on:
+      - sl-api
+    environment:
+      API_URL: http://sl-api:8000
+      NEXT_PUBLIC_API_URL: ${FRONTEND_URL:-http://localhost:3000}/api
+    networks:
+      - sl-internal
+      - sl-external
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    expose:
+      - "3000"
+    # Or direct access:
+    # ports:
+    #   - "3000:3000"
+
+# =============================================================================
+# Networks
+# =============================================================================
+networks:
+  # Internal network for database communication (not exposed)
+  sl-internal:
+    driver: bridge
+    internal: true
+  # External network for reverse proxy access
+  sl-external:
+    driver: bridge
+
+# =============================================================================
+# Volumes
+# =============================================================================
+volumes:
+  sl_postgres_data:
+    driver: local

--- a/deploy/traefik/docker-compose.traefik.yml
+++ b/deploy/traefik/docker-compose.traefik.yml
@@ -1,0 +1,91 @@
+# =============================================================================
+# Structura Ludis - Traefik Reverse Proxy Configuration
+# =============================================================================
+# This file adds Traefik as a reverse proxy with automatic HTTPS via Let's Encrypt.
+#
+# Usage:
+#   1. Configure your domain in .env (DOMAIN and LETSENCRYPT_EMAIL)
+#   2. Run: docker compose -f docker-compose.prod.yml -f traefik/docker-compose.traefik.yml up -d
+#
+# Traefik will automatically:
+#   - Obtain SSL certificates from Let's Encrypt
+#   - Redirect HTTP to HTTPS
+#   - Route traffic to frontend and API
+
+services:
+  # ---------------------------------------------------------------------------
+  # Traefik Reverse Proxy
+  # ---------------------------------------------------------------------------
+  traefik:
+    image: traefik:v3.0
+    container_name: sl_traefik
+    restart: unless-stopped
+    command:
+      # API and Dashboard
+      - "--api.dashboard=true"
+      - "--api.insecure=false"
+      # Docker provider
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--providers.docker.network=sl-external"
+      # Entrypoints
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      # HTTP to HTTPS redirect
+      - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
+      # Let's Encrypt
+      - "--certificatesresolvers.letsencrypt.acme.tlschallenge=true"
+      - "--certificatesresolvers.letsencrypt.acme.email=${LETSENCRYPT_EMAIL}"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+      # Uncomment for staging (testing) certificates:
+      # - "--certificatesresolvers.letsencrypt.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - traefik_letsencrypt:/letsencrypt
+    networks:
+      - sl-external
+    labels:
+      # Dashboard (optional, accessible at traefik.${DOMAIN})
+      - "traefik.enable=true"
+      - "traefik.http.routers.traefik.rule=Host(`traefik.${DOMAIN}`)"
+      - "traefik.http.routers.traefik.entrypoints=websecure"
+      - "traefik.http.routers.traefik.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.traefik.service=api@internal"
+      # Basic auth for dashboard (generate with: htpasswd -nb admin password)
+      # - "traefik.http.routers.traefik.middlewares=traefik-auth"
+      # - "traefik.http.middlewares.traefik-auth.basicauth.users=admin:$$apr1$$..."
+
+  # ---------------------------------------------------------------------------
+  # Override frontend with Traefik labels
+  # ---------------------------------------------------------------------------
+  sl-frontend:
+    labels:
+      - "traefik.enable=true"
+      # Main domain routes to frontend
+      - "traefik.http.routers.frontend.rule=Host(`${DOMAIN}`)"
+      - "traefik.http.routers.frontend.entrypoints=websecure"
+      - "traefik.http.routers.frontend.tls.certresolver=letsencrypt"
+      - "traefik.http.services.frontend.loadbalancer.server.port=3000"
+
+  # ---------------------------------------------------------------------------
+  # Override API with Traefik labels
+  # ---------------------------------------------------------------------------
+  sl-api:
+    labels:
+      - "traefik.enable=true"
+      # API routes (/api/*) go to backend
+      - "traefik.http.routers.api.rule=Host(`${DOMAIN}`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.api.entrypoints=websecure"
+      - "traefik.http.routers.api.tls.certresolver=letsencrypt"
+      - "traefik.http.services.api.loadbalancer.server.port=8000"
+
+# =============================================================================
+# Additional Volumes
+# =============================================================================
+volumes:
+  traefik_letsencrypt:
+    driver: local

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,0 +1,64 @@
+# =============================================================================
+# Structura Ludis Frontend - Production Dockerfile
+# =============================================================================
+# Multi-stage build for optimized Next.js production image
+
+# Stage 1: Dependencies
+FROM node:20-alpine AS deps
+WORKDIR /app
+
+# Copy package files
+COPY package.json package-lock.json ./
+
+# Install dependencies
+RUN npm ci --only=production
+
+# Stage 2: Build
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+# Copy dependencies from deps stage
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Set build-time environment variables
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV NODE_ENV=production
+
+# Build the application
+RUN npm run build
+
+# Stage 3: Production
+FROM node:20-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Create non-root user
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# Copy necessary files from builder
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+
+# Set correct permissions
+RUN chown -R nextjs:nodejs /app
+
+# Switch to non-root user
+USER nextjs
+
+# Expose port
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:3000 || exit 1
+
+# Start the application
+CMD ["node", "server.js"]

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -7,6 +7,9 @@ const nextConfig = {
   // Enable strict mode for better development experience
   reactStrictMode: true,
 
+  // Output standalone build for Docker production deployment
+  output: 'standalone',
+
   // Preserve trailing slashes in URLs (required for FastAPI with redirect_slashes=False)
   skipTrailingSlashRedirect: true,
 


### PR DESCRIPTION
## Summary
- Create `deploy/` folder with production-ready Docker Compose configuration
- Add `.env.example` with fully documented environment variables
- Add Traefik reverse proxy configuration for automatic HTTPS via Let's Encrypt
- Add `README-selfhost.md` with detailed instructions for Synology NAS and Container Manager
- Create `Dockerfile.prod` for both backend (gunicorn with 4 workers) and frontend (Next.js standalone)
- Add gunicorn dependency for production deployment
- Enable standalone output in Next.js config for optimized Docker builds

## Files
```
deploy/
├── .env.example              # Documented environment template
├── docker-compose.prod.yml   # Production compose (no dev volumes)
├── README-selfhost.md        # Self-hosting guide
└── traefik/
    └── docker-compose.traefik.yml  # HTTPS reverse proxy
```

## Test plan
- [ ] Review configuration files
- [ ] Test build with `docker compose -f deploy/docker-compose.prod.yml build`
- [ ] Verify health checks work

🤖 Generated with [Claude Code](https://claude.com/claude-code)